### PR TITLE
bin/ed: remove building with NOCRYPTO option - Infrastructure change to come …

### DIFF
--- a/bin/ed/Makefile
+++ b/bin/ed/Makefile
@@ -1,13 +1,10 @@
-#	$NetBSD: Makefile,v 1.36 2009/07/26 01:58:20 dholland Exp $
+#	$NetBSD: Makefile,v 1.37 2017/05/21 15:28:36 riastradh Exp $
 
 .include <bsd.own.mk>
 
 PROG=	ed
 CPPFLAGS+=-DBACKWARDS
-
-.if (${MKCRYPTO} != "no")
 CPPFLAGS+=-DDES
-.endif
 
 SRCS=	buf.c cbc.c glbl.c io.c main.c re.c sub.c undo.c
 

--- a/bin/ed/cbc.c
+++ b/bin/ed/cbc.c
@@ -1,4 +1,4 @@
-/*	$NetBSD: cbc.c,v 1.23 2014/03/23 05:06:42 dholland Exp $	*/
+/*	$NetBSD: cbc.c,v 1.24 2016/02/01 17:34:00 christos Exp $	*/
 
 /* cbc.c: This file contains the encryption routines for the ed line editor */
 /*-
@@ -72,7 +72,7 @@
 #if 0
 static char *rcsid = "@(#)cbc.c,v 1.2 1994/02/01 00:34:36 alm Exp";
 #else
-__RCSID("$NetBSD: cbc.c,v 1.23 2014/03/23 05:06:42 dholland Exp $");
+__RCSID("$NetBSD: cbc.c,v 1.24 2016/02/01 17:34:00 christos Exp $");
 #endif
 #endif /* not lint */
 
@@ -303,7 +303,7 @@ expand_des_key(char *obuf /* bit pattern */, char *inbuf /* the key itself */)
 		/*
 		 * now translate it, bombing on any illegal hex digit
 		 */
-		for (i = 0; inbuf[i] && i < 16; i++)
+		for (i = 0; i < 16 && inbuf[i]; i++)
 			if ((nbuf[i] = hex_to_binary((int) inbuf[i], 16)) == -1)
 				des_error("bad hex digit in key");
 		while (i < 16)
@@ -323,7 +323,7 @@ expand_des_key(char *obuf /* bit pattern */, char *inbuf /* the key itself */)
 		/*
 		 * now translate it, bombing on any illegal binary digit
 		 */
-		for (i = 0; inbuf[i] && i < 16; i++)
+		for (i = 0; i < 16 && inbuf[i]; i++)
 			if ((nbuf[i] = hex_to_binary((int) inbuf[i], 2)) == -1)
 				des_error("bad binary digit in key");
 		while (i < 64)

--- a/bin/ed/ed.1
+++ b/bin/ed/ed.1
@@ -1,4 +1,4 @@
-.\"	$NetBSD: ed.1,v 1.30 2010/05/14 02:09:58 joerg Exp $
+.\"	$NetBSD: ed.1,v 1.30.40.1 2018/04/08 06:04:08 snj Exp $
 .\"	$OpenBSD: ed.1,v 1.42 2003/07/27 13:25:43 jmc Exp $
 .\"
 .\" Copyright (c) 1993 Andrew Moore, Talke Studio.
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd January 23, 2002
+.Dd April 5, 2018
 .Dt ED 1
 .Os
 .Sh NAME
@@ -34,7 +34,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl
-.Op Fl Esx
+.Op Fl ESsx
 .Op Fl p Ar string
 .Op Ar file
 .Sh DESCRIPTION
@@ -130,6 +130,12 @@ option (deprecated).
 .It Fl E
 Enables the use of extended regular expressions instead of the basic
 regular expressions that are normally used.
+.It Fl S
+Disables using of the
+.Dq !
+command (execuring a subshell).
+Intended to be used by batch jobs like
+.Xr patch 1 .
 .It Fl p Ar string
 Specifies a command prompt.
 This may be toggled on and off with the
@@ -955,6 +961,7 @@ but any changes to the buffer are lost.
 .Xr sed 1 ,
 .Xr sh 1 ,
 .Xr vi 1 ,
+.Xr patch 1 ,
 .Xr regex 3
 .Pp
 USD:09-10


### PR DESCRIPTION
…in a

separate commit.
https://mail-index.netbsd.org/tech-crypto/2017/05/06/msg000719.html
Patch for CVE-2018-049.
Prevent shell execution with r command.
Check bounds before dereferencing in encryption routines.
Document -S to disable ! commands.
Sync with NetBSD-8