### PR TITLE
sbin/newfs_msdos: sync with NetBSD-8

### DIFF
--- a/sbin/newfs_msdos/mkfs_msdos.h
+++ b/sbin/newfs_msdos/mkfs_msdos.h
@@ -1,4 +1,4 @@
-/*	$NetBSD: mkfs_msdos.h,v 1.2 2013/01/23 15:29:15 christos Exp $	*/
+/*	$NetBSD: mkfs_msdos.h,v 1.6 2017/02/17 09:29:35 wiz Exp $	*/
 
 /*-
  * Copyright (c) 2013 The NetBSD Foundation, Inc.
@@ -15,9 +15,6 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. Neither the name of The NetBSD Foundation nor the names of its
- *    contributors may be used to endorse or promote products derived
- *    from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
  * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -41,7 +38,7 @@ AOPT('C', off_t, create_size, 0, "Create file") \
 AOPT('F', uint8_t,  fat_type, 12, "FAT type (12, 16, or 32)") \
 AOPT('I', uint32_t, volume_id, 0, "Volume ID") \
 AOPT('L', char *, volume_label, -1, "Volume Label") \
-AOPT('N', bool, no_create, -2, "Don't create filesystem, print params only") \
+AOPT('N', bool, no_create, -2, "Don't create file system, print params only") \
 AOPT('O', char *, OEM_string, -1, "OEM string") \
 AOPT('S', uint16_t, bytes_per_sector, 1, "Bytes per sector") \
 AOPT('a', uint32_t, sectors_per_fat, 1, "Sectors per FAT") \
@@ -63,6 +60,8 @@ struct msdos_options {
 #define AOPT(_opt, _type, _name, _min, _desc) _type _name;
 ALLOPTS
 #undef AOPT	
+	time_t	timestamp;
+	uint32_t timestamp_set:1;
 	uint32_t volume_id_set:1;
 	uint32_t media_descriptor_set:1;
 	uint32_t hidden_sectors_set:1;

--- a/sbin/newfs_msdos/newfs_msdos.8
+++ b/sbin/newfs_msdos/newfs_msdos.8
@@ -1,4 +1,4 @@
-.\" $NetBSD: newfs_msdos.8,v 1.20 2014/04/24 23:49:40 christos Exp $
+.\" $NetBSD: newfs_msdos.8,v 1.23 2017/02/17 09:29:35 wiz Exp $
 .\"
 .\" Copyright (c) 1998 Robert Nordier
 .\" All rights reserved.
@@ -27,7 +27,7 @@
 .\"
 .\" From: $FreeBSD: src/sbin/newfs_msdos/newfs_msdos.8,v 1.13 2001/08/14 10:01:48 ru Exp $
 .\"
-.Dd April 24, 2014
+.Dd February 16, 2017
 .Dt NEWFS_MSDOS 8
 .Os
 .Sh NAME
@@ -57,6 +57,7 @@
 .Op Fl o Ar hidden
 .Op Fl r Ar reserved
 .Op Fl s Ar total
+.Op Fl T Ar timestamp
 .Op Fl u Ar track-size
 .Ar special
 .Op Ar disktype
@@ -74,9 +75,9 @@ to determine geometry, if required.
 The options are as follow:
 .Bl -tag -width indent
 .It Fl N
-Don't create a file system: just print out parameters.
+Do not create a file system: just print out parameters.
 .It Fl @ Ar offset
-Build the filesystem at the specified offset in bytes in the device or file.
+Build the file system at the specified offset in bytes in the device or file.
 A suffix s, k, m, g (lower or upper case)
 appended to the offset specifies that the
 number is in sectors, kilobytes, megabytes or gigabytes, respectively.
@@ -120,7 +121,7 @@ Sectors per cluster.
 Acceptable values are powers of 2 in the range 1 through 128.
 If the block or cluster size are not specified, the code
 uses a cluster between 512 bytes and 32K depending on
-the filesystem size.
+the file system size.
 .It Fl e Ar dirents
 Number of root directory entries (FAT12 and FAT16 only).
 .It Fl f Ar format
@@ -147,6 +148,13 @@ Number of hidden sectors.
 Number of reserved sectors.
 .It Fl s Ar total
 File system size.
+.It Fl T At timestamp
+Specify a timestamp to be used for file system creation so that
+it can be consistent for reproducible builds.
+The timestamp can be a pathname, where the timestamps are derived from
+that file, a parseable date for parsedate(3) (this option is not
+yet available in the tools build), or an integer value interpreted
+as the number of seconds from the Epoch.
 .It Fl u Ar track-size
 Number of sectors per track.
 .El
@@ -174,7 +182,7 @@ option.
 When the geometry is not available, it is assumed to be
 63 sectors, 255 heads.
 The size is then rounded to become
-a multiple of the track size and avoid complaints by some filesystem code.
+a multiple of the track size and avoid complaints by some file system code.
 .Pp
 FAT file system parameters occupy a "Boot Sector BPB (BIOS Parameter
 Block)" in the first of the "reserved" sectors which precede the actual
@@ -233,6 +241,10 @@ Exit status is 0 on success and 1 on error.
 .Xr fdisk 8 ,
 .Xr newfs 8
 .Sh HISTORY
+A
+.Nm
+utility appeared in
+.Fx 3.0 .
 The
 .Nm
 command first appeared in


### PR DESCRIPTION
Allow 0 timestamp.
Grammar fixes.
Use the create_size if given to compute the real size instead of stat'ing
the file again, which might have been larger to start with.
Document history.