### PR TITLE
Do not define sched_yield to a symbol which doesn't exist.

### DIFF
--- a/include/sched.h
+++ b/include/sched.h
@@ -55,9 +55,11 @@ int	sched_yield(void);
 int	__libc_thr_yield(void);
 __END_DECLS
 
+#ifndef __minix
 #ifndef __LIBPTHREAD_SOURCE__
 #define sched_yield		__libc_thr_yield
 #endif /* __LIBPTHREAD_SOURCE__ */
+#endif /* __minix */
 
 #if defined(_NETBSD_SOURCE)
 


### PR DESCRIPTION
This causes problem in pkgsrc and prevents the use of pth.
It's better to address the issue here until pthread support is mature and
reliance on pth can be removed than to try and bludgeon things in pkgsrc as a
workaround.