### PR TITLE
removed absolute path to /bin/pwd in build.sh so it compiles on nixos

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -506,7 +506,7 @@ initdefaults()
 	# XXX Except that doesn't work on Solaris. Or many Linuces.
 	#
 	unset PWD
-	TOP=$(/bin/pwd -P 2>/dev/null || /bin/pwd 2>/dev/null)
+	TOP=$(/usr/bin/env pwd -P 2>/dev/null || /usr/bin/env pwd 2>/dev/null)
 
 	# The user can set HOST_SH in the environment, or we try to
 	# guess an appropriate value.  Then we set several other


### PR DESCRIPTION
NixOS uses a store-based root filesystem hierarchy so it has almost nothing in /bin or /usr/bin, instead managing the $PATH variable to point to program directories in its store. Absolute paths don't work in it then, except for /usr/bin/env and /bin/sh.