### PR TITLE
Correct Debian 10 cross compile issue.

### DIFF
--- a/external/bsd/llvm/dist/llvm/include/llvm/IR/ValueMap.h
+++ b/external/bsd/llvm/dist/llvm/include/llvm/IR/ValueMap.h
@@ -101,7 +101,7 @@ public:
 
   ~ValueMap() {}
 
-  bool hasMD() const { return MDMap; }
+  bool hasMD() const { return static_cast<bool>(MDMap); }
   MDMapT &MD() {
     if (!MDMap)
       MDMap.reset(new MDMapT);


### PR DESCRIPTION
Cross compile failure with Debian 10.
The attached static cast corrects the issue and allows Minix 3 to compile successfully.

mike@t410:  lsb_release -a
No LSB modules are available.
Distributor ID: Debian
Description:    Debian GNU/Linux 10 (buster)
Release:        10
Codename:       buster

Best regards,
Mike
