### PR TITLE
Cleanup: convert all K&R-style funtion definitions to ANSI-style in minix/drivers and minix/commands

### DIFF
--- a/bin/ksh/c_ksh.c
+++ b/bin/ksh/c_ksh.c
@@ -18,7 +18,8 @@ __RCSID("$NetBSD: c_ksh.c,v 1.18 2011/10/16 17:12:11 joerg Exp $");
 #endif /* __CYGWIN__ */
 
 int
-c_cd(char **wp)
+c_cd(wp)
+	char	**wp;
 {
 	int optc;
 	int physical = Flag(FPHYSICAL);
@@ -185,7 +186,8 @@ c_cd(char **wp)
 }
 
 int
-c_pwd(char **wp)
+c_pwd(wp)
+	char	**wp;
 {
 	int optc;
 	int physical = Flag(FPHYSICAL);
@@ -231,7 +233,8 @@ c_pwd(char **wp)
 }
 
 int
-c_print(char **wp)
+c_print(wp)
+	char **wp;
 {
 #define PO_NL		BIT(0)	/* print newline */
 #define PO_EXPAND	BIT(1)	/* expand backslash sequences */
@@ -454,7 +457,8 @@ c_print(char **wp)
 }
 
 int
-c_whence(char **wp)
+c_whence(wp)
+	char **wp;
 {
 	struct tbl *tp;
 	char *id;
@@ -576,7 +580,8 @@ c_whence(char **wp)
 
 /* Deal with command -vV - command -p dealt with in comexec() */
 int
-c_command(char **wp)
+c_command(wp)
+	char **wp;
 {
 	/* Let c_whence do the work.  Note that c_command() must be
 	 * a distinct function from c_whence() (tested in comexec()).
@@ -586,7 +591,8 @@ c_command(char **wp)
 
 /* typeset, export, and readonly */
 int
-c_typeset(char **wp)
+c_typeset(wp)
+	char **wp;
 {
 	struct block *l = e->loc;
 	struct tbl *vp, **p;
@@ -882,7 +888,8 @@ c_typeset(char **wp)
 }
 	
 int
-c_alias(char **wp)
+c_alias(wp)
+	char **wp;
 {
 	struct table *t = &aliases;
 	int rv = 0, rflag = 0, tflag, Uflag = 0, pflag = 0;
@@ -1018,7 +1025,8 @@ c_alias(char **wp)
 }
 
 int
-c_unalias(char **wp)
+c_unalias(wp)
+	char **wp;
 {
 	register struct table *t = &aliases;
 	register struct tbl *ap;
@@ -1071,7 +1079,8 @@ c_unalias(char **wp)
 
 #ifdef KSH
 int
-c_let(char **wp)
+c_let(wp)
+	char **wp;
 {
 	int rv = 1;
 	long val;
@@ -1090,7 +1099,8 @@ c_let(char **wp)
 #endif /* KSH */
 
 int
-c_jobs(char **wp)
+c_jobs(wp)
+	char **wp;
 {
 	int optc;
 	int flag = 0;
@@ -1128,7 +1138,8 @@ c_jobs(char **wp)
 
 #ifdef JOBS
 int
-c_fgbg(char **wp)
+c_fgbg(wp)
+	char **wp;
 {
 	int bg = strcmp(*wp, "bg") == 0;
 	int UNINITIALIZED(rv);
@@ -1160,7 +1171,11 @@ static char *kill_fmt_entry ARGS((void *arg, int i, char *buf, int buflen));
 
 /* format a single kill item */
 static char *
-kill_fmt_entry(void *arg, int i, char *buf, int buflen)
+kill_fmt_entry(arg, i, buf, buflen)
+	void *arg;
+	int i;
+	char *buf;
+	int buflen;
 {
 	struct kill_info *ki = (struct kill_info *) arg;
 
@@ -1180,7 +1195,8 @@ kill_fmt_entry(void *arg, int i, char *buf, int buflen)
 
 
 int
-c_kill(char **wp)
+c_kill(wp)
+	char **wp;
 {
 	Trap *t = (Trap *) 0;
 	char *p;
@@ -1291,7 +1307,8 @@ c_kill(char **wp)
 }
 
 void
-getopts_reset(int val)
+getopts_reset(val)
+	int val;
 {
 	if (val >= 1) {
 		ksh_getopt_reset(&user_opt,
@@ -1301,7 +1318,8 @@ getopts_reset(int val)
 }
 
 int
-c_getopts(char **wp)
+c_getopts(wp)
+	char **wp;
 {
 	int	argc;
 	const char *options;
@@ -1400,7 +1418,8 @@ c_getopts(char **wp)
 
 #ifdef EMACS
 int
-c_bind(char **wp)
+c_bind(wp)
+	char **wp;
 {
 	int rv = 0, macro = 0, list = 0;
 	register char *cp;
@@ -1469,4 +1488,3 @@ const struct builtin kshbuiltins [] = {
 #endif
 	{NULL, NULL}
 };
-

--- a/bin/ksh/c_ksh.c
+++ b/bin/ksh/c_ksh.c
@@ -18,8 +18,7 @@ __RCSID("$NetBSD: c_ksh.c,v 1.18 2011/10/16 17:12:11 joerg Exp $");
 #endif /* __CYGWIN__ */
 
 int
-c_cd(wp)
-	char	**wp;
+c_cd(char **wp)
 {
 	int optc;
 	int physical = Flag(FPHYSICAL);
@@ -186,8 +185,7 @@ c_cd(wp)
 }
 
 int
-c_pwd(wp)
-	char	**wp;
+c_pwd(char **wp)
 {
 	int optc;
 	int physical = Flag(FPHYSICAL);
@@ -233,8 +231,7 @@ c_pwd(wp)
 }
 
 int
-c_print(wp)
-	char **wp;
+c_print(char **wp)
 {
 #define PO_NL		BIT(0)	/* print newline */
 #define PO_EXPAND	BIT(1)	/* expand backslash sequences */
@@ -457,8 +454,7 @@ c_print(wp)
 }
 
 int
-c_whence(wp)
-	char **wp;
+c_whence(char **wp)
 {
 	struct tbl *tp;
 	char *id;
@@ -580,8 +576,7 @@ c_whence(wp)
 
 /* Deal with command -vV - command -p dealt with in comexec() */
 int
-c_command(wp)
-	char **wp;
+c_command(char **wp)
 {
 	/* Let c_whence do the work.  Note that c_command() must be
 	 * a distinct function from c_whence() (tested in comexec()).
@@ -591,8 +586,7 @@ c_command(wp)
 
 /* typeset, export, and readonly */
 int
-c_typeset(wp)
-	char **wp;
+c_typeset(char **wp)
 {
 	struct block *l = e->loc;
 	struct tbl *vp, **p;
@@ -888,8 +882,7 @@ c_typeset(wp)
 }
 	
 int
-c_alias(wp)
-	char **wp;
+c_alias(char **wp)
 {
 	struct table *t = &aliases;
 	int rv = 0, rflag = 0, tflag, Uflag = 0, pflag = 0;
@@ -1025,8 +1018,7 @@ c_alias(wp)
 }
 
 int
-c_unalias(wp)
-	char **wp;
+c_unalias(char **wp)
 {
 	register struct table *t = &aliases;
 	register struct tbl *ap;
@@ -1079,8 +1071,7 @@ c_unalias(wp)
 
 #ifdef KSH
 int
-c_let(wp)
-	char **wp;
+c_let(char **wp)
 {
 	int rv = 1;
 	long val;
@@ -1099,8 +1090,7 @@ c_let(wp)
 #endif /* KSH */
 
 int
-c_jobs(wp)
-	char **wp;
+c_jobs(char **wp)
 {
 	int optc;
 	int flag = 0;
@@ -1138,8 +1128,7 @@ c_jobs(wp)
 
 #ifdef JOBS
 int
-c_fgbg(wp)
-	char **wp;
+c_fgbg(char **wp)
 {
 	int bg = strcmp(*wp, "bg") == 0;
 	int UNINITIALIZED(rv);
@@ -1171,11 +1160,7 @@ static char *kill_fmt_entry ARGS((void *arg, int i, char *buf, int buflen));
 
 /* format a single kill item */
 static char *
-kill_fmt_entry(arg, i, buf, buflen)
-	void *arg;
-	int i;
-	char *buf;
-	int buflen;
+kill_fmt_entry(void *arg, int i, char *buf, int buflen)
 {
 	struct kill_info *ki = (struct kill_info *) arg;
 
@@ -1195,8 +1180,7 @@ kill_fmt_entry(arg, i, buf, buflen)
 
 
 int
-c_kill(wp)
-	char **wp;
+c_kill(char **wp)
 {
 	Trap *t = (Trap *) 0;
 	char *p;
@@ -1307,8 +1291,7 @@ c_kill(wp)
 }
 
 void
-getopts_reset(val)
-	int val;
+getopts_reset(int val)
 {
 	if (val >= 1) {
 		ksh_getopt_reset(&user_opt,
@@ -1318,8 +1301,7 @@ getopts_reset(val)
 }
 
 int
-c_getopts(wp)
-	char **wp;
+c_getopts(char **wp)
 {
 	int	argc;
 	const char *options;
@@ -1418,8 +1400,7 @@ c_getopts(wp)
 
 #ifdef EMACS
 int
-c_bind(wp)
-	char **wp;
+c_bind(char **wp)
 {
 	int rv = 0, macro = 0, list = 0;
 	register char *cp;
@@ -1488,3 +1469,4 @@ const struct builtin kshbuiltins [] = {
 #endif
 	{NULL, NULL}
 };
+

--- a/bin/ksh/c_sh.c
+++ b/bin/ksh/c_sh.c
@@ -20,15 +20,13 @@ static	char *clocktos ARGS((clock_t t));
 
 /* :, false and true */
 int
-c_label(wp)
-	char **wp;
+c_label(char **wp)
 {
 	return wp[0][0] == 'f' ? 1 : 0;
 }
 
 int
-c_shift(wp)
-	char **wp;
+c_shift(char **wp)
 {
 	register struct block *l = e->loc;
 	register int n;
@@ -59,8 +57,7 @@ c_shift(wp)
 }
 
 int
-c_umask(wp)
-	char **wp;
+c_umask(char **wp)
 {
 	register int i;
 	register char *cp;
@@ -179,8 +176,7 @@ c_umask(wp)
 }
 
 int
-c_dot(wp)
-	char **wp;
+c_dot(char **wp)
 {
 	char *file, *cp;
 	char **argv;
@@ -218,8 +214,7 @@ c_dot(wp)
 }
 
 int
-c_wait(wp)
-	char **wp;
+c_wait(char **wp)
 {
 	int UNINITIALIZED(rv);
 	int sig;
@@ -241,8 +236,7 @@ c_wait(wp)
 }
 
 int
-c_read(wp)
-	char **wp;
+c_read(char **wp)
 {
 	register int c = 0;
 	int expandv = 1, history = 0;
@@ -428,8 +422,7 @@ c_read(wp)
 }
 
 int
-c_eval(wp)
-	char **wp;
+c_eval(char **wp)
 {
 	register struct source *s;
 	int rv;
@@ -472,8 +465,7 @@ c_eval(wp)
 }
 
 int
-c_trap(wp)
-	char **wp;
+c_trap(char **wp)
 {
 	int i;
 	char *s;
@@ -534,8 +526,7 @@ c_trap(wp)
 }
 
 int
-c_exitreturn(wp)
-	char **wp;
+c_exitreturn(char **wp)
 {
 	int how = LEXIT;
 	int n;
@@ -577,8 +568,7 @@ c_exitreturn(wp)
 }
 
 int
-c_brkcont(wp)
-	char **wp;
+c_brkcont(char **wp)
 {
 	int n, quit;
 	struct env *ep, *last_ep = (struct env *) 0;
@@ -632,8 +622,7 @@ c_brkcont(wp)
 }
 
 int
-c_set(wp)
-	char **wp;
+c_set(char **wp)
 {
 	int argi, setargs;
 	struct block *l = e->loc;
@@ -668,8 +657,7 @@ c_set(wp)
 }
 
 int
-c_unset(wp)
-	char **wp;
+c_unset(char **wp)
 {
 	register char *id;
 	int optc, unset_var = 1;
@@ -706,8 +694,7 @@ c_unset(wp)
 }
 
 int
-c_times(wp)
-	char **wp;
+c_times(char **wp)
 {
 	struct tms all;
 
@@ -724,9 +711,7 @@ c_times(wp)
  * time pipeline (really a statement, not a built-in command)
  */
 int
-timex(t, f)
-	struct op *t;
-	int f;
+timex(struct op *t, int f)
 {
 #define TF_NOARGS	BIT(0)
 #define TF_NOREAL	BIT(1)		/* don't report real time */
@@ -781,9 +766,7 @@ timex(t, f)
 }
 
 void
-timex_hook(t, app)
-	struct op *t;
-	char ** volatile *app;
+timex_hook(struct op *t, char ** volatile *app)
 {
 	char **wp = *app;
 	int optc;
@@ -816,8 +799,7 @@ timex_hook(t, app)
 }
 
 static char *
-clocktos(t)
-	clock_t t;
+clocktos(clock_t t)
 {
 	static char temp[22]; /* enough for 64 bit clock_t */
 	register int i;
@@ -842,8 +824,7 @@ clocktos(t)
 
 /* exec with no args - args case is taken care of in comexec() */
 int
-c_exec(wp)
-	char ** wp;
+c_exec(char **wp)
 {
 	int i;
 
@@ -870,8 +851,7 @@ c_exec(wp)
 
 /* dummy function, special case in comexec() */
 int
-c_builtin(wp)
-	char ** wp;
+c_builtin(char **wp)
 {
 	return 0;
 }
@@ -917,3 +897,4 @@ const struct builtin shbuiltins [] = {
 #endif /* OS2 */
 	{NULL, NULL}
 };
+

--- a/bin/ksh/c_sh.c
+++ b/bin/ksh/c_sh.c
@@ -20,13 +20,15 @@ static	char *clocktos ARGS((clock_t t));
 
 /* :, false and true */
 int
-c_label(char **wp)
+c_label(wp)
+	char **wp;
 {
 	return wp[0][0] == 'f' ? 1 : 0;
 }
 
 int
-c_shift(char **wp)
+c_shift(wp)
+	char **wp;
 {
 	register struct block *l = e->loc;
 	register int n;
@@ -57,7 +59,8 @@ c_shift(char **wp)
 }
 
 int
-c_umask(char **wp)
+c_umask(wp)
+	char **wp;
 {
 	register int i;
 	register char *cp;
@@ -176,7 +179,8 @@ c_umask(char **wp)
 }
 
 int
-c_dot(char **wp)
+c_dot(wp)
+	char **wp;
 {
 	char *file, *cp;
 	char **argv;
@@ -214,7 +218,8 @@ c_dot(char **wp)
 }
 
 int
-c_wait(char **wp)
+c_wait(wp)
+	char **wp;
 {
 	int UNINITIALIZED(rv);
 	int sig;
@@ -236,7 +241,8 @@ c_wait(char **wp)
 }
 
 int
-c_read(char **wp)
+c_read(wp)
+	char **wp;
 {
 	register int c = 0;
 	int expandv = 1, history = 0;
@@ -422,7 +428,8 @@ c_read(char **wp)
 }
 
 int
-c_eval(char **wp)
+c_eval(wp)
+	char **wp;
 {
 	register struct source *s;
 	int rv;
@@ -465,7 +472,8 @@ c_eval(char **wp)
 }
 
 int
-c_trap(char **wp)
+c_trap(wp)
+	char **wp;
 {
 	int i;
 	char *s;
@@ -526,7 +534,8 @@ c_trap(char **wp)
 }
 
 int
-c_exitreturn(char **wp)
+c_exitreturn(wp)
+	char **wp;
 {
 	int how = LEXIT;
 	int n;
@@ -568,7 +577,8 @@ c_exitreturn(char **wp)
 }
 
 int
-c_brkcont(char **wp)
+c_brkcont(wp)
+	char **wp;
 {
 	int n, quit;
 	struct env *ep, *last_ep = (struct env *) 0;
@@ -622,7 +632,8 @@ c_brkcont(char **wp)
 }
 
 int
-c_set(char **wp)
+c_set(wp)
+	char **wp;
 {
 	int argi, setargs;
 	struct block *l = e->loc;
@@ -657,7 +668,8 @@ c_set(char **wp)
 }
 
 int
-c_unset(char **wp)
+c_unset(wp)
+	char **wp;
 {
 	register char *id;
 	int optc, unset_var = 1;
@@ -694,7 +706,8 @@ c_unset(char **wp)
 }
 
 int
-c_times(char **wp)
+c_times(wp)
+	char **wp;
 {
 	struct tms all;
 
@@ -711,7 +724,9 @@ c_times(char **wp)
  * time pipeline (really a statement, not a built-in command)
  */
 int
-timex(struct op *t, int f)
+timex(t, f)
+	struct op *t;
+	int f;
 {
 #define TF_NOARGS	BIT(0)
 #define TF_NOREAL	BIT(1)		/* don't report real time */
@@ -766,7 +781,9 @@ timex(struct op *t, int f)
 }
 
 void
-timex_hook(struct op *t, char ** volatile *app)
+timex_hook(t, app)
+	struct op *t;
+	char ** volatile *app;
 {
 	char **wp = *app;
 	int optc;
@@ -799,7 +816,8 @@ timex_hook(struct op *t, char ** volatile *app)
 }
 
 static char *
-clocktos(clock_t t)
+clocktos(t)
+	clock_t t;
 {
 	static char temp[22]; /* enough for 64 bit clock_t */
 	register int i;
@@ -824,7 +842,8 @@ clocktos(clock_t t)
 
 /* exec with no args - args case is taken care of in comexec() */
 int
-c_exec(char **wp)
+c_exec(wp)
+	char ** wp;
 {
 	int i;
 
@@ -851,7 +870,8 @@ c_exec(char **wp)
 
 /* dummy function, special case in comexec() */
 int
-c_builtin(char **wp)
+c_builtin(wp)
+	char ** wp;
 {
 	return 0;
 }
@@ -897,4 +917,3 @@ const struct builtin shbuiltins [] = {
 #endif /* OS2 */
 	{NULL, NULL}
 };
-

--- a/bin/ksh/c_test.c
+++ b/bin/ksh/c_test.c
@@ -106,7 +106,8 @@ static int	ptest_eval ARGS((Test_env *, Test_op, const char *,
 static void	ptest_error ARGS((Test_env *, int, const char *));
 
 int
-c_test(char **wp)
+c_test(wp)
+	char **wp;
 {
 	int argc;
 	int res;
@@ -190,7 +191,10 @@ c_test(char **wp)
  */
 
 Test_op
-test_isop(Test_env *te, Test_meta meta, const char *s)
+test_isop(te, meta, s)
+	Test_env *te;
+	Test_meta meta;
+	const char *s;
 {
 	char sc1;
 	const struct t_op *otab;
@@ -210,7 +214,12 @@ test_isop(Test_env *te, Test_meta meta, const char *s)
 }
 
 int
-test_eval(Test_env *te, Test_op op, const char *opnd1, const char *opnd2, int do_eval)
+test_eval(te, op, opnd1, opnd2, do_eval)
+	Test_env *te;
+	Test_op op;
+	const char *opnd1;
+	const char *opnd2;
+	int do_eval;
 {
 	int res;
 	int not;
@@ -415,7 +424,9 @@ test_eval(Test_env *te, Test_op op, const char *opnd1, const char *opnd2, int do
 
 /* Nasty kludge to handle Korn's bizarre /dev/fd hack */
 static int
-test_stat(const char *pathx, struct stat *statb)
+test_stat(pathx, statb)
+	const char *pathx;
+	struct stat *statb;
 {
 #if !defined(HAVE_DEV_FD)
 	int fd;
@@ -431,7 +442,9 @@ test_stat(const char *pathx, struct stat *statb)
  * non-directories when running as root.
  */
 static int
-test_eaccess(const char *pathx, int mode)
+test_eaccess(pathx, mode)
+	const char *pathx;
+	int mode;
 {
 	int res;
 
@@ -472,7 +485,8 @@ test_eaccess(const char *pathx, int mode)
 }
 
 int
-test_parse(Test_env *te)
+test_parse(te)
+	Test_env *te;
 {
 	int res;
 
@@ -485,7 +499,9 @@ test_parse(Test_env *te)
 }
 
 static int
-test_oexpr(Test_env *te, int do_eval)
+test_oexpr(te, do_eval)
+	Test_env *te;
+	int do_eval;
 {
 	int res;
 
@@ -498,7 +514,9 @@ test_oexpr(Test_env *te, int do_eval)
 }
 
 static int
-test_aexpr(Test_env *te, int do_eval)
+test_aexpr(te, do_eval)
+	Test_env *te;
+	int do_eval;
 {
 	int res;
 
@@ -511,7 +529,9 @@ test_aexpr(Test_env *te, int do_eval)
 }
 
 static int
-test_nexpr(Test_env *te, int do_eval)
+test_nexpr(te, do_eval)
+	Test_env *te;
+	int do_eval;
 {
 	if (!(te->flags & TEF_ERROR) && (*te->isa)(te, TM_NOT))
 		return !test_nexpr(te, do_eval);
@@ -519,7 +539,9 @@ test_nexpr(Test_env *te, int do_eval)
 }
 
 static int
-test_primary(Test_env *te, int do_eval)
+test_primary(te, do_eval)
+	Test_env *te;
+	int do_eval;
 {
 	const char *opnd1, *opnd2;
 	int res;
@@ -578,7 +600,9 @@ test_primary(Test_env *te, int do_eval)
  * TM_UNOP and TM_BINOP, the returned value is a Test_op).
  */
 static int
-ptest_isa(Test_env *te, Test_meta meta)
+ptest_isa(te, meta)
+	Test_env *te;
+	Test_meta meta;
 {
 	/* Order important - indexed by Test_meta values */
 	static const char *const tokens[] = {
@@ -604,7 +628,10 @@ ptest_isa(Test_env *te, Test_meta meta)
 }
 
 static const char *
-ptest_getopnd(Test_env *te, Test_op op, int do_eval)
+ptest_getopnd(te, op, do_eval)
+	Test_env *te;
+	Test_op op;
+	int do_eval;
 {
 	if (te->pos.wp >= te->wp_end)
 		return op == TO_FILTT ? "1" : (const char *) 0;
@@ -612,13 +639,21 @@ ptest_getopnd(Test_env *te, Test_op op, int do_eval)
 }
 
 static int
-ptest_eval(Test_env *te, Test_op op, const char *opnd1, const char *opnd2, int do_eval)
+ptest_eval(te, op, opnd1, opnd2, do_eval)
+	Test_env *te;
+	Test_op op;
+	const char *opnd1;
+	const char *opnd2;
+	int do_eval;
 {
 	return test_eval(te, op, opnd1, opnd2, do_eval);
 }
 
 static void
-ptest_error(Test_env *te, int offset, const char *msg)
+ptest_error(te, offset, msg)
+	Test_env *te;
+	int offset;
+	const char *msg;
 {
 	const char *op = te->pos.wp + offset >= te->wp_end ?
 				(const char *) 0 : te->pos.wp[offset];
@@ -629,4 +664,3 @@ ptest_error(Test_env *te, int offset, const char *msg)
 	else
 		bi_errorf("%s", msg);
 }
-

--- a/bin/ksh/c_test.c
+++ b/bin/ksh/c_test.c
@@ -106,8 +106,7 @@ static int	ptest_eval ARGS((Test_env *, Test_op, const char *,
 static void	ptest_error ARGS((Test_env *, int, const char *));
 
 int
-c_test(wp)
-	char **wp;
+c_test(char **wp)
 {
 	int argc;
 	int res;
@@ -191,10 +190,7 @@ c_test(wp)
  */
 
 Test_op
-test_isop(te, meta, s)
-	Test_env *te;
-	Test_meta meta;
-	const char *s;
+test_isop(Test_env *te, Test_meta meta, const char *s)
 {
 	char sc1;
 	const struct t_op *otab;
@@ -214,12 +210,7 @@ test_isop(te, meta, s)
 }
 
 int
-test_eval(te, op, opnd1, opnd2, do_eval)
-	Test_env *te;
-	Test_op op;
-	const char *opnd1;
-	const char *opnd2;
-	int do_eval;
+test_eval(Test_env *te, Test_op op, const char *opnd1, const char *opnd2, int do_eval)
 {
 	int res;
 	int not;
@@ -424,9 +415,7 @@ test_eval(te, op, opnd1, opnd2, do_eval)
 
 /* Nasty kludge to handle Korn's bizarre /dev/fd hack */
 static int
-test_stat(pathx, statb)
-	const char *pathx;
-	struct stat *statb;
+test_stat(const char *pathx, struct stat *statb)
 {
 #if !defined(HAVE_DEV_FD)
 	int fd;
@@ -442,9 +431,7 @@ test_stat(pathx, statb)
  * non-directories when running as root.
  */
 static int
-test_eaccess(pathx, mode)
-	const char *pathx;
-	int mode;
+test_eaccess(const char *pathx, int mode)
 {
 	int res;
 
@@ -485,8 +472,7 @@ test_eaccess(pathx, mode)
 }
 
 int
-test_parse(te)
-	Test_env *te;
+test_parse(Test_env *te)
 {
 	int res;
 
@@ -499,9 +485,7 @@ test_parse(te)
 }
 
 static int
-test_oexpr(te, do_eval)
-	Test_env *te;
-	int do_eval;
+test_oexpr(Test_env *te, int do_eval)
 {
 	int res;
 
@@ -514,9 +498,7 @@ test_oexpr(te, do_eval)
 }
 
 static int
-test_aexpr(te, do_eval)
-	Test_env *te;
-	int do_eval;
+test_aexpr(Test_env *te, int do_eval)
 {
 	int res;
 
@@ -529,9 +511,7 @@ test_aexpr(te, do_eval)
 }
 
 static int
-test_nexpr(te, do_eval)
-	Test_env *te;
-	int do_eval;
+test_nexpr(Test_env *te, int do_eval)
 {
 	if (!(te->flags & TEF_ERROR) && (*te->isa)(te, TM_NOT))
 		return !test_nexpr(te, do_eval);
@@ -539,9 +519,7 @@ test_nexpr(te, do_eval)
 }
 
 static int
-test_primary(te, do_eval)
-	Test_env *te;
-	int do_eval;
+test_primary(Test_env *te, int do_eval)
 {
 	const char *opnd1, *opnd2;
 	int res;
@@ -600,9 +578,7 @@ test_primary(te, do_eval)
  * TM_UNOP and TM_BINOP, the returned value is a Test_op).
  */
 static int
-ptest_isa(te, meta)
-	Test_env *te;
-	Test_meta meta;
+ptest_isa(Test_env *te, Test_meta meta)
 {
 	/* Order important - indexed by Test_meta values */
 	static const char *const tokens[] = {
@@ -628,10 +604,7 @@ ptest_isa(te, meta)
 }
 
 static const char *
-ptest_getopnd(te, op, do_eval)
-	Test_env *te;
-	Test_op op;
-	int do_eval;
+ptest_getopnd(Test_env *te, Test_op op, int do_eval)
 {
 	if (te->pos.wp >= te->wp_end)
 		return op == TO_FILTT ? "1" : (const char *) 0;
@@ -639,21 +612,13 @@ ptest_getopnd(te, op, do_eval)
 }
 
 static int
-ptest_eval(te, op, opnd1, opnd2, do_eval)
-	Test_env *te;
-	Test_op op;
-	const char *opnd1;
-	const char *opnd2;
-	int do_eval;
+ptest_eval(Test_env *te, Test_op op, const char *opnd1, const char *opnd2, int do_eval)
 {
 	return test_eval(te, op, opnd1, opnd2, do_eval);
 }
 
 static void
-ptest_error(te, offset, msg)
-	Test_env *te;
-	int offset;
-	const char *msg;
+ptest_error(Test_env *te, int offset, const char *msg)
 {
 	const char *op = te->pos.wp + offset >= te->wp_end ?
 				(const char *) 0 : te->pos.wp[offset];
@@ -664,3 +629,4 @@ ptest_error(te, offset, msg)
 	else
 		bi_errorf("%s", msg);
 }
+

--- a/bin/ksh/c_test.h
+++ b/bin/ksh/c_test.h
@@ -53,4 +53,3 @@ Test_op	test_isop ARGS((Test_env *te, Test_meta meta, const char *s));
 int     test_eval ARGS((Test_env *te, Test_op op, const char *opnd1,
 			const char *opnd2, int do_eval));
 int	test_parse ARGS((Test_env *te));
-

--- a/bin/ksh/c_test.h
+++ b/bin/ksh/c_test.h
@@ -53,3 +53,4 @@ Test_op	test_isop ARGS((Test_env *te, Test_meta meta, const char *s));
 int     test_eval ARGS((Test_env *te, Test_op op, const char *opnd1,
 			const char *opnd2, int do_eval));
 int	test_parse ARGS((Test_env *te));
+

--- a/bin/ksh/c_ulimit.c
+++ b/bin/ksh/c_ulimit.c
@@ -47,7 +47,8 @@ extern	long ulimit();
 #endif /* RLIM_INFINITY */
 
 int
-c_ulimit(char **wp)
+c_ulimit(wp)
+	char **wp;
 {
 	static const struct limits {
 		const char	*name;
@@ -289,4 +290,3 @@ c_ulimit(char **wp)
 	}
 	return 0;
 }
-

--- a/bin/ksh/c_ulimit.c
+++ b/bin/ksh/c_ulimit.c
@@ -47,8 +47,7 @@ extern	long ulimit();
 #endif /* RLIM_INFINITY */
 
 int
-c_ulimit(wp)
-	char **wp;
+c_ulimit(char **wp)
 {
 	static const struct limits {
 		const char	*name;
@@ -290,3 +289,4 @@ c_ulimit(wp)
 	}
 	return 0;
 }
+

--- a/bin/ksh/conf-end.h
+++ b/bin/ksh/conf-end.h
@@ -55,4 +55,3 @@
 # define GCC_FUNC_ATTR(x)
 # define GCC_FUNC_ATTR2(x,y)
 #endif /* HAVE_GCC_FUNC_ATTR */
-

--- a/bin/ksh/conf-end.h
+++ b/bin/ksh/conf-end.h
@@ -55,3 +55,4 @@
 # define GCC_FUNC_ATTR(x)
 # define GCC_FUNC_ATTR2(x,y)
 #endif /* HAVE_GCC_FUNC_ATTR */
+

--- a/bin/ksh/edit.c
+++ b/bin/ksh/edit.c
@@ -87,7 +87,8 @@ x_init()
 
 #if defined(TIOCGWINSZ)
 static RETSIGTYPE
-x_sigwinch(int sig)
+x_sigwinch(sig)
+    	int sig;
 {
 	got_sigwinch = 1;
 	return RETSIGVAL;
@@ -128,7 +129,9 @@ check_sigwinch ARGS((void))
  * read an edited command line
  */
 int
-x_read(char *buf, size_t len)
+x_read(buf, len)
+	char *buf;
+	size_t len;
 {
 	int	i;
 
@@ -178,26 +181,29 @@ x_getc()
 }
 
 void
-x_flush(void)
+x_flush()
 {
 	shf_flush(shl_out);
 }
 
 void
-x_putc(int c)
+x_putc(c)
+	int c;
 {
 	shf_putc(c, shl_out);
 }
 
 void
-x_puts(const char *s)
+x_puts(s)
+	const char *s;
 {
 	while (*s != 0)
 		shf_putc(*s++, shl_out);
 }
 
 bool_t
-x_mode(bool_t onoff)
+x_mode(onoff)
+	bool_t	onoff;
 {
 	static bool_t	x_cur_mode;
 	bool_t		prev;
@@ -330,7 +336,9 @@ x_mode(bool_t onoff)
  *      length
  */
 int
-promptlen(const char *cp, const char **spp)
+promptlen(cp, spp)
+    const char  *cp;
+    const char **spp;
 {
     int count = 0;
     const char *sp = cp;
@@ -370,7 +378,8 @@ promptlen(const char *cp, const char **spp)
 }
 
 void
-set_editmode(const char *ed)
+set_editmode(ed)
+	const char *ed;
 {
 	static const enum sh_flag edit_flags[] = {
 #ifdef EMACS
@@ -404,7 +413,10 @@ set_editmode(const char *ed)
  * moved to the start of the line after (un)commenting.
  */
 int
-x_do_comment(char *buf, int bsize, int *lenp)
+x_do_comment(buf, bsize, lenp)
+	char *buf;
+	int bsize;
+	int *lenp;
 {
 	int i, j;
 	int len = *lenp;
@@ -482,7 +494,10 @@ x_complete_word(str, slen, is_command, nwordsp, ret)
 #endif /* 0 */
 
 void
-x_print_expansions(int nwords, char *const *words, int is_command)
+x_print_expansions(nwords, words, is_command)
+	int nwords;
+	char *const *words;
+	int is_command;
 {
 	int use_copy = 0;
 	int prefix_len;
@@ -538,7 +553,11 @@ x_print_expansions(int nwords, char *const *words, int is_command)
  *	- returns number of matching strings
  */
 static int
-x_file_glob(int flags, const char *str, int slen, char ***wordsp)
+x_file_glob(flags, str, slen, wordsp)
+	int flags;
+	const char *str;
+	int slen;
+	char ***wordsp;
 {
 	char *toglob;
 	char **words;
@@ -626,7 +645,9 @@ static int path_order_cmp(const void *aa, const void *bb);
 
 /* Compare routine used in x_command_glob() */
 static int
-path_order_cmp(const void *aa, const void *bb)
+path_order_cmp(aa, bb)
+	const void *aa;
+	const void *bb;
 {
 	const struct path_order_info *a = (const struct path_order_info *) aa;
 	const struct path_order_info *b = (const struct path_order_info *) bb;
@@ -637,7 +658,11 @@ path_order_cmp(const void *aa, const void *bb)
 }
 
 static int
-x_command_glob(int flags, const char *str, int slen, char ***wordsp)
+x_command_glob(flags, str, slen, wordsp)
+	int flags;
+	const char *str;
+	int slen;
+	char ***wordsp;
 {
 	char *toglob;
 	char *pat;
@@ -731,8 +756,12 @@ x_command_glob(int flags, const char *str, int slen, char ***wordsp)
 			    || (c) == '`' || (c) == '=' || (c) == ':' )
 
 static int
-x_locate_word(const char *buf, int buflen, int pos, int *startp,
-			  int *is_commandp)
+x_locate_word(buf, buflen, pos, startp, is_commandp)
+	const char *buf;
+	int buflen;
+	int pos;
+	int *startp;
+	int *is_commandp;
 {
 	int p;
 	int start, end;
@@ -784,8 +813,15 @@ x_locate_word(const char *buf, int buflen, int pos, int *startp,
 }
 
 int
-x_cf_glob(int flags, const char *buf, int buflen, int pos, int *startp,
-	  	  int *endp, char ***wordsp, int *is_commandp)
+x_cf_glob(flags, buf, buflen, pos, startp, endp, wordsp, is_commandp)
+	int flags;
+	const char *buf;
+	int buflen;
+	int pos;
+	int *startp;
+	int *endp;
+	char ***wordsp;
+	int *is_commandp;
 {
 	int len;
 	int nwords;
@@ -821,7 +857,9 @@ x_cf_glob(int flags, const char *buf, int buflen, int pos, int *startp,
  * new string is returned.
  */
 static char *
-add_glob(const char *str, int slen)
+add_glob(str, slen)
+	const char *str;
+	int slen;
 {
 	char *toglob;
 	char *s;
@@ -860,7 +898,9 @@ add_glob(const char *str, int slen)
  * Find longest common prefix
  */
 int
-x_longest_prefix(int nwords, char *const *words)
+x_longest_prefix(nwords, words)
+	int nwords;
+	char *const *words;
 {
 	int i, j;
 	int prefix_len;
@@ -881,7 +921,9 @@ x_longest_prefix(int nwords, char *const *words)
 }
 
 void
-x_free_words(int nwords, char **words)
+x_free_words(nwords, words)
+	int nwords;
+	char **words;
 {
 	int i;
 
@@ -904,7 +946,9 @@ x_free_words(int nwords, char **words)
  *			0
  */
 int
-x_basename(const char *s, const char *se)
+x_basename(s, se)
+	const char *s;
+	const char *se;
 {
 	const char *p;
 
@@ -929,7 +973,10 @@ x_basename(const char *s, const char *se)
  * are added to wp.
  */
 static void
-glob_table(const char *pat, XPtrV *wp, struct table *tp)
+glob_table(pat, wp, tp)
+	const char *pat;
+	XPtrV *wp;
+	struct table *tp;
 {
 	struct tstate ts;
 	struct tbl *te;
@@ -941,7 +988,11 @@ glob_table(const char *pat, XPtrV *wp, struct table *tp)
 }
 
 static void
-glob_path(int flags, const char *pat, XPtrV *wp, const char *xpath)
+glob_path(flags, pat, wp, xpath)
+	int flags;
+	const char *pat;
+	XPtrV *wp;
+	const char *xpath;
 {
 	const char *sp, *p;
 	char *xp;
@@ -1011,7 +1062,10 @@ glob_path(int flags, const char *pat, XPtrV *wp, const char *xpath)
  * keybinding-specific function
  */
 int
-x_escape(const char *s, size_t len, int (*putbuf_func)(const char *, size_t))
+x_escape(s, len, putbuf_func)
+	const char *s;
+	size_t len;
+	int (*putbuf_func) ARGS((const char *, size_t));
 {
 	size_t add, wlen;
 	const char *ifs = str_val(local("IFS", 0));
@@ -1039,4 +1093,3 @@ x_escape(const char *s, size_t len, int (*putbuf_func)(const char *, size_t))
 	return (rval);
 }
 #endif /* EDIT */
-

--- a/bin/ksh/edit.c
+++ b/bin/ksh/edit.c
@@ -87,8 +87,7 @@ x_init()
 
 #if defined(TIOCGWINSZ)
 static RETSIGTYPE
-x_sigwinch(sig)
-    	int sig;
+x_sigwinch(int sig)
 {
 	got_sigwinch = 1;
 	return RETSIGVAL;
@@ -129,9 +128,7 @@ check_sigwinch ARGS((void))
  * read an edited command line
  */
 int
-x_read(buf, len)
-	char *buf;
-	size_t len;
+x_read(char *buf, size_t len)
 {
 	int	i;
 
@@ -181,29 +178,26 @@ x_getc()
 }
 
 void
-x_flush()
+x_flush(void)
 {
 	shf_flush(shl_out);
 }
 
 void
-x_putc(c)
-	int c;
+x_putc(int c)
 {
 	shf_putc(c, shl_out);
 }
 
 void
-x_puts(s)
-	const char *s;
+x_puts(const char *s)
 {
 	while (*s != 0)
 		shf_putc(*s++, shl_out);
 }
 
 bool_t
-x_mode(onoff)
-	bool_t	onoff;
+x_mode(bool_t onoff)
 {
 	static bool_t	x_cur_mode;
 	bool_t		prev;
@@ -336,9 +330,7 @@ x_mode(onoff)
  *      length
  */
 int
-promptlen(cp, spp)
-    const char  *cp;
-    const char **spp;
+promptlen(const char *cp, const char **spp)
 {
     int count = 0;
     const char *sp = cp;
@@ -378,8 +370,7 @@ promptlen(cp, spp)
 }
 
 void
-set_editmode(ed)
-	const char *ed;
+set_editmode(const char *ed)
 {
 	static const enum sh_flag edit_flags[] = {
 #ifdef EMACS
@@ -413,10 +404,7 @@ set_editmode(ed)
  * moved to the start of the line after (un)commenting.
  */
 int
-x_do_comment(buf, bsize, lenp)
-	char *buf;
-	int bsize;
-	int *lenp;
+x_do_comment(char *buf, int bsize, int *lenp)
 {
 	int i, j;
 	int len = *lenp;
@@ -494,10 +482,7 @@ x_complete_word(str, slen, is_command, nwordsp, ret)
 #endif /* 0 */
 
 void
-x_print_expansions(nwords, words, is_command)
-	int nwords;
-	char *const *words;
-	int is_command;
+x_print_expansions(int nwords, char *const *words, int is_command)
 {
 	int use_copy = 0;
 	int prefix_len;
@@ -553,11 +538,7 @@ x_print_expansions(nwords, words, is_command)
  *	- returns number of matching strings
  */
 static int
-x_file_glob(flags, str, slen, wordsp)
-	int flags;
-	const char *str;
-	int slen;
-	char ***wordsp;
+x_file_glob(int flags, const char *str, int slen, char ***wordsp)
 {
 	char *toglob;
 	char **words;
@@ -645,9 +626,7 @@ static int path_order_cmp(const void *aa, const void *bb);
 
 /* Compare routine used in x_command_glob() */
 static int
-path_order_cmp(aa, bb)
-	const void *aa;
-	const void *bb;
+path_order_cmp(const void *aa, const void *bb)
 {
 	const struct path_order_info *a = (const struct path_order_info *) aa;
 	const struct path_order_info *b = (const struct path_order_info *) bb;
@@ -658,11 +637,7 @@ path_order_cmp(aa, bb)
 }
 
 static int
-x_command_glob(flags, str, slen, wordsp)
-	int flags;
-	const char *str;
-	int slen;
-	char ***wordsp;
+x_command_glob(int flags, const char *str, int slen, char ***wordsp)
 {
 	char *toglob;
 	char *pat;
@@ -756,12 +731,8 @@ x_command_glob(flags, str, slen, wordsp)
 			    || (c) == '`' || (c) == '=' || (c) == ':' )
 
 static int
-x_locate_word(buf, buflen, pos, startp, is_commandp)
-	const char *buf;
-	int buflen;
-	int pos;
-	int *startp;
-	int *is_commandp;
+x_locate_word(const char *buf, int buflen, int pos, int *startp,
+			  int *is_commandp)
 {
 	int p;
 	int start, end;
@@ -813,15 +784,8 @@ x_locate_word(buf, buflen, pos, startp, is_commandp)
 }
 
 int
-x_cf_glob(flags, buf, buflen, pos, startp, endp, wordsp, is_commandp)
-	int flags;
-	const char *buf;
-	int buflen;
-	int pos;
-	int *startp;
-	int *endp;
-	char ***wordsp;
-	int *is_commandp;
+x_cf_glob(int flags, const char *buf, int buflen, int pos, int *startp,
+	  	  int *endp, char ***wordsp, int *is_commandp)
 {
 	int len;
 	int nwords;
@@ -857,9 +821,7 @@ x_cf_glob(flags, buf, buflen, pos, startp, endp, wordsp, is_commandp)
  * new string is returned.
  */
 static char *
-add_glob(str, slen)
-	const char *str;
-	int slen;
+add_glob(const char *str, int slen)
 {
 	char *toglob;
 	char *s;
@@ -898,9 +860,7 @@ add_glob(str, slen)
  * Find longest common prefix
  */
 int
-x_longest_prefix(nwords, words)
-	int nwords;
-	char *const *words;
+x_longest_prefix(int nwords, char *const *words)
 {
 	int i, j;
 	int prefix_len;
@@ -921,9 +881,7 @@ x_longest_prefix(nwords, words)
 }
 
 void
-x_free_words(nwords, words)
-	int nwords;
-	char **words;
+x_free_words(int nwords, char **words)
 {
 	int i;
 
@@ -946,9 +904,7 @@ x_free_words(nwords, words)
  *			0
  */
 int
-x_basename(s, se)
-	const char *s;
-	const char *se;
+x_basename(const char *s, const char *se)
 {
 	const char *p;
 
@@ -973,10 +929,7 @@ x_basename(s, se)
  * are added to wp.
  */
 static void
-glob_table(pat, wp, tp)
-	const char *pat;
-	XPtrV *wp;
-	struct table *tp;
+glob_table(const char *pat, XPtrV *wp, struct table *tp)
 {
 	struct tstate ts;
 	struct tbl *te;
@@ -988,11 +941,7 @@ glob_table(pat, wp, tp)
 }
 
 static void
-glob_path(flags, pat, wp, xpath)
-	int flags;
-	const char *pat;
-	XPtrV *wp;
-	const char *xpath;
+glob_path(int flags, const char *pat, XPtrV *wp, const char *xpath)
 {
 	const char *sp, *p;
 	char *xp;
@@ -1062,10 +1011,7 @@ glob_path(flags, pat, wp, xpath)
  * keybinding-specific function
  */
 int
-x_escape(s, len, putbuf_func)
-	const char *s;
-	size_t len;
-	int (*putbuf_func) ARGS((const char *, size_t));
+x_escape(const char *s, size_t len, int (*putbuf_func)(const char *, size_t))
 {
 	size_t add, wlen;
 	const char *ifs = str_val(local("IFS", 0));
@@ -1093,3 +1039,4 @@ x_escape(s, len, putbuf_func)
 	return (rval);
 }
 #endif /* EDIT */
+

--- a/bin/ksh/edit.h
+++ b/bin/ksh/edit.h
@@ -85,3 +85,4 @@ int 	x_vi		ARGS((char *buf, size_t len));
  * comment-column:40
  * End:
  */
+

--- a/bin/ksh/edit.h
+++ b/bin/ksh/edit.h
@@ -85,4 +85,3 @@ int 	x_vi		ARGS((char *buf, size_t len));
  * comment-column:40
  * End:
  */
-

--- a/bin/ksh/emacs.c
+++ b/bin/ksh/emacs.c
@@ -414,7 +414,8 @@ x_emacs(buf, len)
 }
 
 static int
-x_insert(int c)
+x_insert(c)
+	int c;
 {
 	char	str[2];
 
@@ -433,7 +434,8 @@ x_insert(int c)
 }
 
 static int
-x_ins_string(int c)
+x_ins_string(c)
+	int c;
 {
 	if (macroptr)   {
 		x_e_putc(BEL);
@@ -450,7 +452,9 @@ x_ins_string(int c)
 static int x_do_ins(const char *cp, int len);
 
 static int
-x_do_ins(const char *cp, int len)
+x_do_ins(cp, len)
+	const char *cp;
+	int len;
 {
 	if (xep+len >= xend) {
 		x_e_putc(BEL);
@@ -465,7 +469,8 @@ x_do_ins(const char *cp, int len)
 }
 
 static int
-x_ins(char *s)
+x_ins(s)
+	char	*s;
 {
 	char *cp = xcp;
 	register int	adj = x_adj_done;
@@ -495,7 +500,9 @@ x_ins(char *s)
  * this is used for x_escape() in do_complete()
  */
 static int
-x_emacs_putbuf(const char *s, size_t len)
+x_emacs_putbuf(s, len)
+	const char *s;
+	size_t len;
 {
 	int rval;
 
@@ -505,7 +512,8 @@ x_emacs_putbuf(const char *s, size_t len)
 }
 
 static int
-x_del_back(int c)
+x_del_back(c)
+	int c;
 {
 	int col = xcp - xbuf;
 
@@ -521,7 +529,8 @@ x_del_back(int c)
 }
 
 static int
-x_del_char(int c)
+x_del_char(c)
+	int c;
 {
 	int nleft = xep - xcp;
 
@@ -537,7 +546,9 @@ x_del_char(int c)
 
 /* Delete nc chars to the right of the cursor (including cursor position) */
 static void
-x_delete(int nc, int push)
+x_delete(nc, push)
+	int nc;
+	int push;
 {
 	int	i,j;
 	char	*cp;
@@ -592,35 +603,39 @@ x_delete(int nc, int push)
 }
 
 static int
-x_del_bword(int c)
+x_del_bword(c)
+	int c;
 {
 	x_delete(x_bword(), TRUE);
 	return KSTD;
 }
 
 static int
-x_mv_bword(int c)
+x_mv_bword(c)
+	int c;
 {
 	(void)x_bword();
 	return KSTD;
 }
 
 static int
-x_mv_fword(int c)
+x_mv_fword(c)
+	int c;
 {
 	x_goto(xcp + x_fword());
 	return KSTD;
 }
 
 static int
-x_del_fword(int c)
+x_del_fword(c)
+	int c;
 {
 	x_delete(x_fword(), TRUE);
 	return KSTD;
 }
 
 static int
-x_bword(void)
+x_bword()
 {
 	int	nc = 0;
 	register char *cp = xcp;
@@ -647,7 +662,7 @@ x_bword(void)
 }
 
 static int
-x_fword(void)
+x_fword()
 {
 	int	nc = 0;
 	register char	*cp = xcp;
@@ -673,7 +688,8 @@ x_fword(void)
 }
 
 static void
-x_goto(register char *cp)
+x_goto(cp)
+	register char *cp;
 {
   if (cp < xbp || cp >= (xbp + x_displen))
   {
@@ -700,7 +716,8 @@ x_goto(register char *cp)
 }
 
 static void
-x_bs(int c)
+x_bs(c)
+	int c;
 {
 	register int i;
 	i = x_size(c);
@@ -709,7 +726,8 @@ x_bs(int c)
 }
 
 static int
-x_size_str(register char *cp)
+x_size_str(cp)
+	register char *cp;
 {
 	register int size = 0;
 	while (*cp)
@@ -718,7 +736,8 @@ x_size_str(register char *cp)
 }
 
 static int
-x_size(int c)
+x_size(c)
+	int c;
 {
 	if (c=='\t')
 		return 4;	/* Kludge, tabs are always four spaces. */
@@ -728,7 +747,8 @@ x_size(int c)
 }
 
 static void
-x_zots(register char *str)
+x_zots(str)
+	register char *str;
 {
   register int	adj = x_adj_done;
 
@@ -738,7 +758,8 @@ x_zots(register char *str)
 }
 
 static void
-x_zotc(int c)
+x_zotc(c)
+	int c;
 {
 	if (c == '\t')  {
 		/*  Kludge, tabs are always four spaces.  */
@@ -751,7 +772,8 @@ x_zotc(int c)
 }
 
 static int
-x_mv_back(int c)
+x_mv_back(c)
+	int c;
 {
 	int col = xcp - xbuf;
 
@@ -766,7 +788,8 @@ x_mv_back(int c)
 }
 
 static int
-x_mv_forw(int c)
+x_mv_forw(c)
+	int c;
 {
 	int nleft = xep - xcp;
 
@@ -781,7 +804,8 @@ x_mv_forw(int c)
 }
 
 static int
-x_search_char_forw(int c)
+x_search_char_forw(c)
+	int c;
 {
 	char *cp = xcp;
 
@@ -801,7 +825,8 @@ x_search_char_forw(int c)
 }
 
 static int
-x_search_char_back(int c)
+x_search_char_back(c)
+	int c;
 {
 	char *cp = xcp, *p;
 
@@ -822,7 +847,8 @@ x_search_char_back(int c)
 }
 
 static int
-x_newline(int c)
+x_newline(c)
+	int c;
 {
 	x_e_putc('\r');
 	x_e_putc('\n');
@@ -832,7 +858,8 @@ x_newline(int c)
 }
 
 static int
-x_end_of_text(int c)
+x_end_of_text(c)
+	int c;
 {
 	return KEOL;
 }
@@ -850,7 +877,8 @@ static int x_next_com(c) int c; { x_load_hist(x_histp + x_arg); return KSTD;}
  * want so we'll simply go to the oldest one.
  */
 static int
-x_goto_hist(int c)
+x_goto_hist(c)
+	int c;
 {
 	if (x_arg_defaulted)
 		x_load_hist(histlist);
@@ -860,7 +888,8 @@ x_goto_hist(int c)
 }
 
 static void
-x_load_hist(register char **hp)
+x_load_hist(hp)
+	register char **hp;
 {
 	int	oldsize;
 
@@ -881,14 +910,16 @@ x_load_hist(register char **hp)
 }
 
 static int
-x_nl_next_com(int c)
+x_nl_next_com(c)
+	int	c;
 {
 	x_nextcmd = source->line - (histptr - x_histp) + 1;
 	return (x_newline(c));
 }
 
 static int
-x_eot_del(int c)
+x_eot_del(c)
+	int	c;
 {
 	if (xep == xbuf && x_arg_defaulted)
 		return (x_end_of_text(c));
@@ -898,7 +929,8 @@ x_eot_del(int c)
 
 /* reverse incremental history search */
 static int
-x_search_hist(int c)
+x_search_hist(c)
+	int c;
 {
 	int offset = -1;	/* offset of match in xbuf, else -1 */
 	char pat [256+1];	/* pattern buffer */
@@ -960,7 +992,10 @@ x_search_hist(int c)
 
 /* search backward from current line */
 static int
-x_search(char *pat, int sameline, int offset)
+x_search(pat, sameline, offset)
+	char *pat;
+	int sameline;
+	int offset;
 {
 	register char **hp;
 	int i;
@@ -982,7 +1017,8 @@ x_search(char *pat, int sameline, int offset)
 
 /* return position of first match of pattern in string, else -1 */
 static int
-x_match(char *str, char *pat)
+x_match(str, pat)
+	char *str, *pat;
 {
 	if (*pat == '^') {
 		return (strncmp(str, pat+1, strlen(pat+1)) == 0) ? 0 : -1;
@@ -993,7 +1029,8 @@ x_match(char *str, char *pat)
 }
 
 static int
-x_del_line(int c)
+x_del_line(c)
+	int c;
 {
 	int	i, j;
 
@@ -1011,21 +1048,24 @@ x_del_line(int c)
 }
 
 static int
-x_mv_end(int c)
+x_mv_end(c)
+	int c;
 {
 	x_goto(xep);
 	return KSTD;
 }
 
 static int
-x_mv_begin(int c)
+x_mv_begin(c)
+	int c;
 {
 	x_goto(xbuf);
 	return KSTD;
 }
 
 static int
-x_draw_line(int c)
+x_draw_line(c)
+	int c;
 {
 	x_redraw(-1);
 	return KSTD;
@@ -1037,7 +1077,8 @@ x_draw_line(int c)
  * redrawing.
  */
 static void
-x_redraw(int limit)
+x_redraw(limit)
+  int limit;
 {
 	int	i, j;
 	char	*cp;
@@ -1092,7 +1133,8 @@ x_redraw(int limit)
 }
 
 static int
-x_transpose(int c)
+x_transpose(c)
+	int c;
 {
 	char	tmp;
 
@@ -1144,21 +1186,24 @@ x_transpose(int c)
 }
 
 static int
-x_literal(int c)
+x_literal(c)
+	int c;
 {
 	x_curprefix = -1;
 	return KSTD;
 }
 
 static int
-x_meta1(int c)
+x_meta1(c)
+	int c;
 {
 	x_curprefix = 1;
 	return KSTD;
 }
 
 static int
-x_meta2(int c)
+x_meta2(c)
+	int c;
 {
 	x_curprefix = 2;
 	return KSTD;
@@ -1166,7 +1211,8 @@ x_meta2(int c)
 
 #ifdef OS2
 static int
-x_meta3(int c)
+x_meta3(c)
+	int c;
 {
 	x_curprefix = 3;
 	return KSTD;
@@ -1174,7 +1220,8 @@ x_meta3(int c)
 #endif /* OS2 */
 
 static int
-x_kill(int c)
+x_kill(c)
+	int c;
 {
 	int col = xcp - xbuf;
 	int lastcol = xep - xbuf;
@@ -1194,7 +1241,8 @@ x_kill(int c)
 }
 
 static void
-x_push(int nchars)
+x_push(nchars)
+	int nchars;
 {
 	char	*cp = str_nsave(xcp, nchars, AEDIT);
 	if (killstack[killsp])
@@ -1204,7 +1252,8 @@ x_push(int nchars)
 }
 
 static int
-x_yank(int c)
+x_yank(c)
+	int c;
 {
 	if (killsp == 0)
 		killtp = KILLSIZE;
@@ -1222,7 +1271,8 @@ x_yank(int c)
 }
 
 static int
-x_meta_yank(int c)
+x_meta_yank(c)
+	int c;
 {
 	int	len;
 	if ((x_last_command != XFUNC_yank && x_last_command != XFUNC_meta_yank)
@@ -1246,7 +1296,8 @@ x_meta_yank(int c)
 }
 
 static int
-x_abort(int c)
+x_abort(c)
+	int c;
 {
 	/* x_zotc(c); */
 	xlp = xep = xcp = xbp = xbuf;
@@ -1256,14 +1307,16 @@ x_abort(int c)
 }
 
 static int
-x_error(int c)
+x_error(c)
+	int c;
 {
 	x_e_putc(BEL);
 	return KSTD;
 }
 
 static int
-x_stuffreset(int c)
+x_stuffreset(c)
+	int c;
 {
 #ifdef TIOCSTI
 	(void)x_stuff(c);
@@ -1279,7 +1332,8 @@ x_stuffreset(int c)
 }
 
 static int
-x_stuff(int c)
+x_stuff(c)
+	int c;
 {
 #if 0 || defined TIOCSTI
 	char	ch = c;
@@ -1293,7 +1347,9 @@ x_stuff(int c)
 }
 
 static char *
-x_mapin(const char *cp, Area *area)
+x_mapin(cp, area)
+	const char *cp;
+	Area *area;
 {
 	char *new, *op;
 
@@ -1323,7 +1379,8 @@ x_mapin(const char *cp, Area *area)
 }
 
 static char *
-x_mapout(int c)
+x_mapout(c)
+	int c;
 {
 	static char buf[8];
 	register char *p = buf;
@@ -1344,7 +1401,8 @@ x_mapout(int c)
 }
 
 static void
-x_print(int prefix, int key)
+x_print(prefix, key)
+	int prefix, key;
 {
 	if (prefix == 1)
 		shprintf("%s", x_mapout(x_prefix1));
@@ -1361,10 +1419,11 @@ x_print(int prefix, int key)
 		shprintf("'%s'\n", x_atab[prefix][key]);
 }
 
-/* macro for bind -m */
-/* list for bind -l */
 int
-x_bind(const char *a1, const char *a2, int macro, int list)
+x_bind(a1, a2, macro, list)
+	const char *a1, *a2;
+	int macro;		/* bind -m */
+	int list;		/* bind -l */
 {
 	Findex f;
 	int prefix, key;
@@ -1458,7 +1517,7 @@ x_bind(const char *a1, const char *a2, int macro, int list)
 }
 
 void
-x_init_emacs(void)
+x_init_emacs()
 {
 	size_t i;
 	register int j;
@@ -1494,7 +1553,9 @@ x_init_emacs(void)
 static void bind_if_not_bound(int p, int k, int func);
 
 static void
-bind_if_not_bound(int p, int k, int func)
+bind_if_not_bound(p, k, func)
+	int p, k;
+	int func;
 {
 	/* Has user already bound this key?  If so, don't override it */
 	if (x_bound[((p) * X_TABSZ + (k)) / 8]
@@ -1505,7 +1566,8 @@ bind_if_not_bound(int p, int k, int func)
 }
 
 void
-x_emacs_keys(X_chars *ec)
+x_emacs_keys(ec)
+	X_chars *ec;
 {
 	if (ec->erase >= 0) {
 		bind_if_not_bound(0, ec->erase, XFUNC_del_back);
@@ -1522,14 +1584,16 @@ x_emacs_keys(X_chars *ec)
 }
 
 static int
-x_set_mark(int c)
+x_set_mark(c)
+	int c;
 {
 	xmp = xcp;
 	return KSTD;
 }
 
 static int
-x_kill_region(int c)
+x_kill_region(c)
+	int c;
 {
 	int	rsize;
 	char	*xr;
@@ -1552,7 +1616,8 @@ x_kill_region(int c)
 }
 
 static int
-x_xchg_point_mark(int c)
+x_xchg_point_mark(c)
+	int c;
 {
 	char	*tmp;
 
@@ -1567,7 +1632,8 @@ x_xchg_point_mark(int c)
 }
 
 static int
-x_version(int c)
+x_version(c)
+	int c;
 {
 	char *o_xbuf = xbuf, *o_xend = xend;
 	char *o_xbp = xbp, *o_xep = xep, *o_xcp = xcp;
@@ -1596,14 +1662,16 @@ x_version(int c)
 }
 
 static int
-x_noop(int c)
+x_noop(c)
+	int c;
 {
 	return KSTD;
 }
 
 #ifdef SILLY
 static int
-x_game_of_life(int c)
+x_game_of_life(c)
+	int c;
 {
 	char	newbuf [256+1];
 	register char *ip, *op;
@@ -1659,49 +1727,57 @@ x_game_of_life(int c)
 
 
 static int
-x_comp_comm(int c)
+x_comp_comm(c)
+	int c;
 {
 	do_complete(XCF_COMMAND, CT_COMPLETE);
 	return KSTD;
 }
 static int
-x_list_comm(int c)
+x_list_comm(c)
+	int c;
 {
 	do_complete(XCF_COMMAND, CT_LIST);
 	return KSTD;
 }
 static int
-x_complete(int c)
+x_complete(c)
+	int c;
 {
 	do_complete(XCF_COMMAND_FILE, CT_COMPLETE);
 	return KSTD;
 }
 static int
-x_enumerate(int c)
+x_enumerate(c)
+	int c;
 {
 	do_complete(XCF_COMMAND_FILE, CT_LIST);
 	return KSTD;
 }
 static int
-x_comp_file(int c)
+x_comp_file(c)
+	int c;
 {
 	do_complete(XCF_FILE, CT_COMPLETE);
 	return KSTD;
 }
 static int
-x_list_file(int c)
+x_list_file(c)
+	int c;
 {
 	do_complete(XCF_FILE, CT_LIST);
 	return KSTD;
 }
 static int
-x_comp_list(int c)
+x_comp_list(c)
+	int c;
 {
 	do_complete(XCF_COMMAND_FILE, CT_COMPLIST);
 	return KSTD;
 }
 static int
-x_expand(int c)
+x_expand(c)
+	int c;
 {
 	char **words;
 	int nwords = 0;
@@ -1734,9 +1810,10 @@ x_expand(int c)
 }
 
 /* type == 0 for list, 1 for complete and 2 for complete-list */
-/* flags == XCF_{COMMAND,FILE,COMMAND_FILE}*/
 static void
-do_complete(int flags, Comp_type type)
+do_complete(flags, type)
+	int flags;	/* XCF_{COMMAND,FILE,COMMAND_FILE} */
+	Comp_type type;
 {
 	char **words;
 	int nwords;
@@ -1801,7 +1878,7 @@ do_complete(int flags, Comp_type type)
  */
 
 static void
-x_adjust(void)
+x_adjust()
 {
   x_adj_done++;			/* flag the fact that we were called. */
   /*
@@ -1817,13 +1894,14 @@ x_adjust(void)
 static int unget_char = -1;
 
 static void
-x_e_ungetc(int c)
+x_e_ungetc(c)
+	int c;
 {
 	unget_char = c;
 }
 
 static int
-x_e_getc(void)
+x_e_getc()
 {
 	int c;
 	
@@ -1843,7 +1921,8 @@ x_e_getc(void)
 }
 
 static void
-x_e_putc(int c)
+x_e_putc(c)
+	int c;
 {
   if (c == '\r' || c == '\n')
     x_col = 0;
@@ -1873,7 +1952,8 @@ x_e_putc(int c)
 
 #ifdef DEBUG
 static int
-x_debug_info(int c)
+x_debug_info(c)
+	int c;
 {
 	x_flush();
 	shellf("\nksh debug:\n");
@@ -1890,7 +1970,8 @@ x_debug_info(int c)
 #endif
 
 static void
-x_e_puts(const char *s)
+x_e_puts(s)
+	const char *s;
 {
   register int	adj = x_adj_done;
 
@@ -1909,7 +1990,8 @@ x_e_puts(const char *s)
  */
 
 static int
-x_set_arg(int c)
+x_set_arg(c)
+	int c;
 {
 	int n = 0;
 	int first = 1;
@@ -1932,7 +2014,8 @@ x_set_arg(int c)
 
 /* Comment or uncomment the current line. */
 static int
-x_comment(int c)
+x_comment(c)
+	int c;
 {
 	int oldsize = x_size_str(xbuf);
 	int len = xep - xbuf;
@@ -1968,7 +2051,8 @@ x_comment(int c)
  */
 
 static int
-x_prev_histword(int c)
+x_prev_histword(c)
+	int c;
 {
   register char *rcp;
   char *cp;
@@ -2017,21 +2101,24 @@ x_prev_histword(int c)
 
 /* Uppercase N(1) words */
 static int
-x_fold_upper(int c)
+x_fold_upper(c)
+  int c;
 {
 	return x_fold_case('U');
 }
 
 /* Lowercase N(1) words */
 static int
-x_fold_lower(int c)
+x_fold_lower(c)
+  int c;
 {
 	return x_fold_case('L');
 }
 
 /* Lowercase N(1) words */
 static int
-x_fold_capitalize(int c)
+x_fold_capitalize(c)
+  int c;
 {
 	return x_fold_case('C');
 }
@@ -2048,7 +2135,8 @@ x_fold_capitalize(int c)
  */
 
 static int
-x_fold_case(int c)
+x_fold_case(c)
+	int c;
 {
 	char *cp = xcp;
 	
@@ -2115,7 +2203,7 @@ x_fold_case(int c)
  */
 
 static char *
-x_lastcp(void)
+x_lastcp()
 {
   register char *rcp;
   register int i;
@@ -2131,4 +2219,3 @@ x_lastcp(void)
 }
 
 #endif /* EDIT */
-

--- a/bin/ksh/emacs.c
+++ b/bin/ksh/emacs.c
@@ -414,8 +414,7 @@ x_emacs(buf, len)
 }
 
 static int
-x_insert(c)
-	int c;
+x_insert(int c)
 {
 	char	str[2];
 
@@ -434,8 +433,7 @@ x_insert(c)
 }
 
 static int
-x_ins_string(c)
-	int c;
+x_ins_string(int c)
 {
 	if (macroptr)   {
 		x_e_putc(BEL);
@@ -452,9 +450,7 @@ x_ins_string(c)
 static int x_do_ins(const char *cp, int len);
 
 static int
-x_do_ins(cp, len)
-	const char *cp;
-	int len;
+x_do_ins(const char *cp, int len)
 {
 	if (xep+len >= xend) {
 		x_e_putc(BEL);
@@ -469,8 +465,7 @@ x_do_ins(cp, len)
 }
 
 static int
-x_ins(s)
-	char	*s;
+x_ins(char *s)
 {
 	char *cp = xcp;
 	register int	adj = x_adj_done;
@@ -500,9 +495,7 @@ x_ins(s)
  * this is used for x_escape() in do_complete()
  */
 static int
-x_emacs_putbuf(s, len)
-	const char *s;
-	size_t len;
+x_emacs_putbuf(const char *s, size_t len)
 {
 	int rval;
 
@@ -512,8 +505,7 @@ x_emacs_putbuf(s, len)
 }
 
 static int
-x_del_back(c)
-	int c;
+x_del_back(int c)
 {
 	int col = xcp - xbuf;
 
@@ -529,8 +521,7 @@ x_del_back(c)
 }
 
 static int
-x_del_char(c)
-	int c;
+x_del_char(int c)
 {
 	int nleft = xep - xcp;
 
@@ -546,9 +537,7 @@ x_del_char(c)
 
 /* Delete nc chars to the right of the cursor (including cursor position) */
 static void
-x_delete(nc, push)
-	int nc;
-	int push;
+x_delete(int nc, int push)
 {
 	int	i,j;
 	char	*cp;
@@ -603,39 +592,35 @@ x_delete(nc, push)
 }
 
 static int
-x_del_bword(c)
-	int c;
+x_del_bword(int c)
 {
 	x_delete(x_bword(), TRUE);
 	return KSTD;
 }
 
 static int
-x_mv_bword(c)
-	int c;
+x_mv_bword(int c)
 {
 	(void)x_bword();
 	return KSTD;
 }
 
 static int
-x_mv_fword(c)
-	int c;
+x_mv_fword(int c)
 {
 	x_goto(xcp + x_fword());
 	return KSTD;
 }
 
 static int
-x_del_fword(c)
-	int c;
+x_del_fword(int c)
 {
 	x_delete(x_fword(), TRUE);
 	return KSTD;
 }
 
 static int
-x_bword()
+x_bword(void)
 {
 	int	nc = 0;
 	register char *cp = xcp;
@@ -662,7 +647,7 @@ x_bword()
 }
 
 static int
-x_fword()
+x_fword(void)
 {
 	int	nc = 0;
 	register char	*cp = xcp;
@@ -688,8 +673,7 @@ x_fword()
 }
 
 static void
-x_goto(cp)
-	register char *cp;
+x_goto(register char *cp)
 {
   if (cp < xbp || cp >= (xbp + x_displen))
   {
@@ -716,8 +700,7 @@ x_goto(cp)
 }
 
 static void
-x_bs(c)
-	int c;
+x_bs(int c)
 {
 	register int i;
 	i = x_size(c);
@@ -726,8 +709,7 @@ x_bs(c)
 }
 
 static int
-x_size_str(cp)
-	register char *cp;
+x_size_str(register char *cp)
 {
 	register int size = 0;
 	while (*cp)
@@ -736,8 +718,7 @@ x_size_str(cp)
 }
 
 static int
-x_size(c)
-	int c;
+x_size(int c)
 {
 	if (c=='\t')
 		return 4;	/* Kludge, tabs are always four spaces. */
@@ -747,8 +728,7 @@ x_size(c)
 }
 
 static void
-x_zots(str)
-	register char *str;
+x_zots(register char *str)
 {
   register int	adj = x_adj_done;
 
@@ -758,8 +738,7 @@ x_zots(str)
 }
 
 static void
-x_zotc(c)
-	int c;
+x_zotc(int c)
 {
 	if (c == '\t')  {
 		/*  Kludge, tabs are always four spaces.  */
@@ -772,8 +751,7 @@ x_zotc(c)
 }
 
 static int
-x_mv_back(c)
-	int c;
+x_mv_back(int c)
 {
 	int col = xcp - xbuf;
 
@@ -788,8 +766,7 @@ x_mv_back(c)
 }
 
 static int
-x_mv_forw(c)
-	int c;
+x_mv_forw(int c)
 {
 	int nleft = xep - xcp;
 
@@ -804,8 +781,7 @@ x_mv_forw(c)
 }
 
 static int
-x_search_char_forw(c)
-	int c;
+x_search_char_forw(int c)
 {
 	char *cp = xcp;
 
@@ -825,8 +801,7 @@ x_search_char_forw(c)
 }
 
 static int
-x_search_char_back(c)
-	int c;
+x_search_char_back(int c)
 {
 	char *cp = xcp, *p;
 
@@ -847,8 +822,7 @@ x_search_char_back(c)
 }
 
 static int
-x_newline(c)
-	int c;
+x_newline(int c)
 {
 	x_e_putc('\r');
 	x_e_putc('\n');
@@ -858,8 +832,7 @@ x_newline(c)
 }
 
 static int
-x_end_of_text(c)
-	int c;
+x_end_of_text(int c)
 {
 	return KEOL;
 }
@@ -877,8 +850,7 @@ static int x_next_com(c) int c; { x_load_hist(x_histp + x_arg); return KSTD;}
  * want so we'll simply go to the oldest one.
  */
 static int
-x_goto_hist(c)
-	int c;
+x_goto_hist(int c)
 {
 	if (x_arg_defaulted)
 		x_load_hist(histlist);
@@ -888,8 +860,7 @@ x_goto_hist(c)
 }
 
 static void
-x_load_hist(hp)
-	register char **hp;
+x_load_hist(register char **hp)
 {
 	int	oldsize;
 
@@ -910,16 +881,14 @@ x_load_hist(hp)
 }
 
 static int
-x_nl_next_com(c)
-	int	c;
+x_nl_next_com(int c)
 {
 	x_nextcmd = source->line - (histptr - x_histp) + 1;
 	return (x_newline(c));
 }
 
 static int
-x_eot_del(c)
-	int	c;
+x_eot_del(int c)
 {
 	if (xep == xbuf && x_arg_defaulted)
 		return (x_end_of_text(c));
@@ -929,8 +898,7 @@ x_eot_del(c)
 
 /* reverse incremental history search */
 static int
-x_search_hist(c)
-	int c;
+x_search_hist(int c)
 {
 	int offset = -1;	/* offset of match in xbuf, else -1 */
 	char pat [256+1];	/* pattern buffer */
@@ -992,10 +960,7 @@ x_search_hist(c)
 
 /* search backward from current line */
 static int
-x_search(pat, sameline, offset)
-	char *pat;
-	int sameline;
-	int offset;
+x_search(char *pat, int sameline, int offset)
 {
 	register char **hp;
 	int i;
@@ -1017,8 +982,7 @@ x_search(pat, sameline, offset)
 
 /* return position of first match of pattern in string, else -1 */
 static int
-x_match(str, pat)
-	char *str, *pat;
+x_match(char *str, char *pat)
 {
 	if (*pat == '^') {
 		return (strncmp(str, pat+1, strlen(pat+1)) == 0) ? 0 : -1;
@@ -1029,8 +993,7 @@ x_match(str, pat)
 }
 
 static int
-x_del_line(c)
-	int c;
+x_del_line(int c)
 {
 	int	i, j;
 
@@ -1048,24 +1011,21 @@ x_del_line(c)
 }
 
 static int
-x_mv_end(c)
-	int c;
+x_mv_end(int c)
 {
 	x_goto(xep);
 	return KSTD;
 }
 
 static int
-x_mv_begin(c)
-	int c;
+x_mv_begin(int c)
 {
 	x_goto(xbuf);
 	return KSTD;
 }
 
 static int
-x_draw_line(c)
-	int c;
+x_draw_line(int c)
 {
 	x_redraw(-1);
 	return KSTD;
@@ -1077,8 +1037,7 @@ x_draw_line(c)
  * redrawing.
  */
 static void
-x_redraw(limit)
-  int limit;
+x_redraw(int limit)
 {
 	int	i, j;
 	char	*cp;
@@ -1133,8 +1092,7 @@ x_redraw(limit)
 }
 
 static int
-x_transpose(c)
-	int c;
+x_transpose(int c)
 {
 	char	tmp;
 
@@ -1186,24 +1144,21 @@ x_transpose(c)
 }
 
 static int
-x_literal(c)
-	int c;
+x_literal(int c)
 {
 	x_curprefix = -1;
 	return KSTD;
 }
 
 static int
-x_meta1(c)
-	int c;
+x_meta1(int c)
 {
 	x_curprefix = 1;
 	return KSTD;
 }
 
 static int
-x_meta2(c)
-	int c;
+x_meta2(int c)
 {
 	x_curprefix = 2;
 	return KSTD;
@@ -1211,8 +1166,7 @@ x_meta2(c)
 
 #ifdef OS2
 static int
-x_meta3(c)
-	int c;
+x_meta3(int c)
 {
 	x_curprefix = 3;
 	return KSTD;
@@ -1220,8 +1174,7 @@ x_meta3(c)
 #endif /* OS2 */
 
 static int
-x_kill(c)
-	int c;
+x_kill(int c)
 {
 	int col = xcp - xbuf;
 	int lastcol = xep - xbuf;
@@ -1241,8 +1194,7 @@ x_kill(c)
 }
 
 static void
-x_push(nchars)
-	int nchars;
+x_push(int nchars)
 {
 	char	*cp = str_nsave(xcp, nchars, AEDIT);
 	if (killstack[killsp])
@@ -1252,8 +1204,7 @@ x_push(nchars)
 }
 
 static int
-x_yank(c)
-	int c;
+x_yank(int c)
 {
 	if (killsp == 0)
 		killtp = KILLSIZE;
@@ -1271,8 +1222,7 @@ x_yank(c)
 }
 
 static int
-x_meta_yank(c)
-	int c;
+x_meta_yank(int c)
 {
 	int	len;
 	if ((x_last_command != XFUNC_yank && x_last_command != XFUNC_meta_yank)
@@ -1296,8 +1246,7 @@ x_meta_yank(c)
 }
 
 static int
-x_abort(c)
-	int c;
+x_abort(int c)
 {
 	/* x_zotc(c); */
 	xlp = xep = xcp = xbp = xbuf;
@@ -1307,16 +1256,14 @@ x_abort(c)
 }
 
 static int
-x_error(c)
-	int c;
+x_error(int c)
 {
 	x_e_putc(BEL);
 	return KSTD;
 }
 
 static int
-x_stuffreset(c)
-	int c;
+x_stuffreset(int c)
 {
 #ifdef TIOCSTI
 	(void)x_stuff(c);
@@ -1332,8 +1279,7 @@ x_stuffreset(c)
 }
 
 static int
-x_stuff(c)
-	int c;
+x_stuff(int c)
 {
 #if 0 || defined TIOCSTI
 	char	ch = c;
@@ -1347,9 +1293,7 @@ x_stuff(c)
 }
 
 static char *
-x_mapin(cp, area)
-	const char *cp;
-	Area *area;
+x_mapin(const char *cp, Area *area)
 {
 	char *new, *op;
 
@@ -1379,8 +1323,7 @@ x_mapin(cp, area)
 }
 
 static char *
-x_mapout(c)
-	int c;
+x_mapout(int c)
 {
 	static char buf[8];
 	register char *p = buf;
@@ -1401,8 +1344,7 @@ x_mapout(c)
 }
 
 static void
-x_print(prefix, key)
-	int prefix, key;
+x_print(int prefix, int key)
 {
 	if (prefix == 1)
 		shprintf("%s", x_mapout(x_prefix1));
@@ -1419,11 +1361,10 @@ x_print(prefix, key)
 		shprintf("'%s'\n", x_atab[prefix][key]);
 }
 
+/* macro for bind -m */
+/* list for bind -l */
 int
-x_bind(a1, a2, macro, list)
-	const char *a1, *a2;
-	int macro;		/* bind -m */
-	int list;		/* bind -l */
+x_bind(const char *a1, const char *a2, int macro, int list)
 {
 	Findex f;
 	int prefix, key;
@@ -1517,7 +1458,7 @@ x_bind(a1, a2, macro, list)
 }
 
 void
-x_init_emacs()
+x_init_emacs(void)
 {
 	size_t i;
 	register int j;
@@ -1553,9 +1494,7 @@ x_init_emacs()
 static void bind_if_not_bound(int p, int k, int func);
 
 static void
-bind_if_not_bound(p, k, func)
-	int p, k;
-	int func;
+bind_if_not_bound(int p, int k, int func)
 {
 	/* Has user already bound this key?  If so, don't override it */
 	if (x_bound[((p) * X_TABSZ + (k)) / 8]
@@ -1566,8 +1505,7 @@ bind_if_not_bound(p, k, func)
 }
 
 void
-x_emacs_keys(ec)
-	X_chars *ec;
+x_emacs_keys(X_chars *ec)
 {
 	if (ec->erase >= 0) {
 		bind_if_not_bound(0, ec->erase, XFUNC_del_back);
@@ -1584,16 +1522,14 @@ x_emacs_keys(ec)
 }
 
 static int
-x_set_mark(c)
-	int c;
+x_set_mark(int c)
 {
 	xmp = xcp;
 	return KSTD;
 }
 
 static int
-x_kill_region(c)
-	int c;
+x_kill_region(int c)
 {
 	int	rsize;
 	char	*xr;
@@ -1616,8 +1552,7 @@ x_kill_region(c)
 }
 
 static int
-x_xchg_point_mark(c)
-	int c;
+x_xchg_point_mark(int c)
 {
 	char	*tmp;
 
@@ -1632,8 +1567,7 @@ x_xchg_point_mark(c)
 }
 
 static int
-x_version(c)
-	int c;
+x_version(int c)
 {
 	char *o_xbuf = xbuf, *o_xend = xend;
 	char *o_xbp = xbp, *o_xep = xep, *o_xcp = xcp;
@@ -1662,16 +1596,14 @@ x_version(c)
 }
 
 static int
-x_noop(c)
-	int c;
+x_noop(int c)
 {
 	return KSTD;
 }
 
 #ifdef SILLY
 static int
-x_game_of_life(c)
-	int c;
+x_game_of_life(int c)
 {
 	char	newbuf [256+1];
 	register char *ip, *op;
@@ -1727,57 +1659,49 @@ x_game_of_life(c)
 
 
 static int
-x_comp_comm(c)
-	int c;
+x_comp_comm(int c)
 {
 	do_complete(XCF_COMMAND, CT_COMPLETE);
 	return KSTD;
 }
 static int
-x_list_comm(c)
-	int c;
+x_list_comm(int c)
 {
 	do_complete(XCF_COMMAND, CT_LIST);
 	return KSTD;
 }
 static int
-x_complete(c)
-	int c;
+x_complete(int c)
 {
 	do_complete(XCF_COMMAND_FILE, CT_COMPLETE);
 	return KSTD;
 }
 static int
-x_enumerate(c)
-	int c;
+x_enumerate(int c)
 {
 	do_complete(XCF_COMMAND_FILE, CT_LIST);
 	return KSTD;
 }
 static int
-x_comp_file(c)
-	int c;
+x_comp_file(int c)
 {
 	do_complete(XCF_FILE, CT_COMPLETE);
 	return KSTD;
 }
 static int
-x_list_file(c)
-	int c;
+x_list_file(int c)
 {
 	do_complete(XCF_FILE, CT_LIST);
 	return KSTD;
 }
 static int
-x_comp_list(c)
-	int c;
+x_comp_list(int c)
 {
 	do_complete(XCF_COMMAND_FILE, CT_COMPLIST);
 	return KSTD;
 }
 static int
-x_expand(c)
-	int c;
+x_expand(int c)
 {
 	char **words;
 	int nwords = 0;
@@ -1810,10 +1734,9 @@ x_expand(c)
 }
 
 /* type == 0 for list, 1 for complete and 2 for complete-list */
+/* flags == XCF_{COMMAND,FILE,COMMAND_FILE}*/
 static void
-do_complete(flags, type)
-	int flags;	/* XCF_{COMMAND,FILE,COMMAND_FILE} */
-	Comp_type type;
+do_complete(int flags, Comp_type type)
 {
 	char **words;
 	int nwords;
@@ -1878,7 +1801,7 @@ do_complete(flags, type)
  */
 
 static void
-x_adjust()
+x_adjust(void)
 {
   x_adj_done++;			/* flag the fact that we were called. */
   /*
@@ -1894,14 +1817,13 @@ x_adjust()
 static int unget_char = -1;
 
 static void
-x_e_ungetc(c)
-	int c;
+x_e_ungetc(int c)
 {
 	unget_char = c;
 }
 
 static int
-x_e_getc()
+x_e_getc(void)
 {
 	int c;
 	
@@ -1921,8 +1843,7 @@ x_e_getc()
 }
 
 static void
-x_e_putc(c)
-	int c;
+x_e_putc(int c)
 {
   if (c == '\r' || c == '\n')
     x_col = 0;
@@ -1952,8 +1873,7 @@ x_e_putc(c)
 
 #ifdef DEBUG
 static int
-x_debug_info(c)
-	int c;
+x_debug_info(int c)
 {
 	x_flush();
 	shellf("\nksh debug:\n");
@@ -1970,8 +1890,7 @@ x_debug_info(c)
 #endif
 
 static void
-x_e_puts(s)
-	const char *s;
+x_e_puts(const char *s)
 {
   register int	adj = x_adj_done;
 
@@ -1990,8 +1909,7 @@ x_e_puts(s)
  */
 
 static int
-x_set_arg(c)
-	int c;
+x_set_arg(int c)
 {
 	int n = 0;
 	int first = 1;
@@ -2014,8 +1932,7 @@ x_set_arg(c)
 
 /* Comment or uncomment the current line. */
 static int
-x_comment(c)
-	int c;
+x_comment(int c)
 {
 	int oldsize = x_size_str(xbuf);
 	int len = xep - xbuf;
@@ -2051,8 +1968,7 @@ x_comment(c)
  */
 
 static int
-x_prev_histword(c)
-	int c;
+x_prev_histword(int c)
 {
   register char *rcp;
   char *cp;
@@ -2101,24 +2017,21 @@ x_prev_histword(c)
 
 /* Uppercase N(1) words */
 static int
-x_fold_upper(c)
-  int c;
+x_fold_upper(int c)
 {
 	return x_fold_case('U');
 }
 
 /* Lowercase N(1) words */
 static int
-x_fold_lower(c)
-  int c;
+x_fold_lower(int c)
 {
 	return x_fold_case('L');
 }
 
 /* Lowercase N(1) words */
 static int
-x_fold_capitalize(c)
-  int c;
+x_fold_capitalize(int c)
 {
 	return x_fold_case('C');
 }
@@ -2135,8 +2048,7 @@ x_fold_capitalize(c)
  */
 
 static int
-x_fold_case(c)
-	int c;
+x_fold_case(int c)
 {
 	char *cp = xcp;
 	
@@ -2203,7 +2115,7 @@ x_fold_case(c)
  */
 
 static char *
-x_lastcp()
+x_lastcp(void)
 {
   register char *rcp;
   register int i;
@@ -2219,3 +2131,4 @@ x_lastcp()
 }
 
 #endif /* EDIT */
+

--- a/bin/ksh/eval.c
+++ b/bin/ksh/eval.c
@@ -64,7 +64,9 @@ static void	alt_expand ARGS((XPtrV *wp, char *start, char *exp_start,
 
 /* compile and expand word */
 char *
-substitute(const char *cp, int f)
+substitute(cp, f)
+	const char *cp;
+	int f;
 {
 	struct source *s, *sold;
 
@@ -83,7 +85,9 @@ substitute(const char *cp, int f)
  * expand arg-list
  */
 char **
-eval(register char **ap, int f)
+eval(ap, f)
+	register char **ap;
+	int f;
 {
 	XPtrV w;
 
@@ -108,7 +112,9 @@ eval(register char **ap, int f)
  * expand string
  */
 char *
-evalstr(char *cp, int f)
+evalstr(cp, f)
+	char *cp;
+	int f;
 {
 	XPtrV w;
 
@@ -124,7 +130,9 @@ evalstr(char *cp, int f)
  * used from iosetup to expand redirection files
  */
 char *
-evalonestr(register char *cp, int f)
+evalonestr(cp, f)
+	register char *cp;
+	int f;
 {
 	XPtrV w;
 
@@ -156,12 +164,11 @@ typedef struct SubType {
 	struct SubType *next;	/* poped type (to avoid re-allocating) */
 } SubType;
 
-/* cp - input word
- * wp - output words
- * f - DO* flags
- */
 void
-expand(char *cp, register XPtrV *wp, int f)
+expand(cp, wp, f)
+	char *cp;		/* input word */
+	register XPtrV *wp;	/* output words */
+	int f;			/* DO* flags */
 {
 	register int UNINITIALIZED(c);
 	register int type;	/* expansion type */
@@ -675,7 +682,7 @@ expand(char *cp, register XPtrV *wp, int f)
 				quote &= ~2; /* undo temporary */
 
 			if (make_magic) {
-			 	make_magic = 0;
+				make_magic = 0;
 				fdo |= DOMAGIC_ | (f & DOGLOB);
 				*dp++ = MAGIC;
 			} else if (ISMAGIC(c)) {
@@ -690,11 +697,14 @@ expand(char *cp, register XPtrV *wp, int f)
 
 /*
  * Prepare to generate the string returned by ${} substitution.
- * stypep: becomes qualifier type
- * slenp: " " len (=, :=, etc) valid iff *stypep != 0
  */
 static int
-varsub(Expand *xp, char *sp, char *word, int *stypep, int *slenp)
+varsub(xp, sp, word, stypep, slenp)
+	Expand *xp;
+	char *sp;
+	char *word;
+	int *stypep;	/* becomes qualifier type */
+	int *slenp;	/* " " len (=, :=, etc.) valid iff *stypep != 0 */
 {
 	int c;
 	int state;	/* next state: XBASE, XARG, XSUB, XNULLSUB */
@@ -840,7 +850,9 @@ varsub(Expand *xp, char *sp, char *word, int *stypep, int *slenp)
  * Run the command in $(...) and read its output.
  */
 static int
-comsub(register Expand *xp, char *cp)
+comsub(xp, cp)
+	register Expand *xp;
+	char *cp;
 {
 	Source *s, *sold;
 	register struct op *t;
@@ -893,7 +905,10 @@ comsub(register Expand *xp, char *cp)
  */
 
 static char *
-trimsub(register char *str, char *pat, int how)
+trimsub(str, pat, how)
+	register char *str;
+	char *pat;
+	int how;
 {
 	register char *end = strchr(str, 0);
 	register char *p, c;
@@ -943,7 +958,10 @@ trimsub(register char *str, char *pat, int how)
 
 /* XXX cp not const 'cause slashes are temporarily replaced with nulls... */
 static void
-glob(char *cp, register XPtrV *wp, int markdirs)
+glob(cp, wp, markdirs)
+	char *cp;
+	register XPtrV *wp;
+	int markdirs;
 {
 	int oldsize = XPsize(*wp);
 
@@ -963,7 +981,10 @@ glob(char *cp, register XPtrV *wp, int markdirs)
  * the number of matches found.
  */
 int
-glob_str(char *cp, XPtrV *wp, int markdirs)
+glob_str(cp, wp, markdirs)
+	char *cp;
+	XPtrV *wp;
+	int markdirs;
 {
 	int oldsize = XPsize(*wp);
 	XString xs;
@@ -976,15 +997,13 @@ glob_str(char *cp, XPtrV *wp, int markdirs)
 	return XPsize(*wp) - oldsize;
 }
 
-/*
- * xs - dest string
- * xpp - prt to dest end
- * sp - source path
- * wp - output list
- * check - GF_* paths
- */
 static void
-globit(XString *xs, char **xpp, char *sp, register XPtrV *wp, int check)
+globit(xs, xpp, sp, wp, check)
+	XString *xs;		/* dest string */
+	char **xpp;		/* ptr to dest end */
+	char *sp;		/* source path */
+	register XPtrV *wp;	/* output list */
+	int check;		/* GF_* flags */
 {
 	register char *np;	/* next source component */
 	char *xp = *xpp;
@@ -1168,7 +1187,10 @@ copy_non_glob(xs, xpp, p)
 
 /* remove MAGIC from string */
 char *
-debunk(char *dp, const char *sp, size_t dlen)
+debunk(dp, sp, dlen)
+	char *dp;
+	const char *sp;
+	size_t dlen;
 {
 	char *d, *s;
 
@@ -1198,7 +1220,11 @@ debunk(char *dp, const char *sp, size_t dlen)
  * past the name, otherwise returns 0.
  */
 static char *
-maybe_expand_tilde(char *p, XString *dsp, char **dpp, int isassign)
+maybe_expand_tilde(p, dsp, dpp, isassign)
+	char *p;
+	XString *dsp;
+	char **dpp;
+	int isassign;
 {
 	XString ts;
 	char *dp = *dpp;
@@ -1236,7 +1262,8 @@ maybe_expand_tilde(char *p, XString *dsp, char **dpp, int isassign)
  */
 
 static char *
-tilde(char *cp)
+tilde(cp)
+	char *cp;
 {
 	char *dp;
 
@@ -1262,7 +1289,8 @@ tilde(char *cp)
  */
 
 static char *
-homedir(char *name)
+homedir(name)
+	char *name;
 {
 	register struct tbl *ap;
 
@@ -1294,7 +1322,11 @@ homedir(char *name)
 
 #ifdef BRACE_EXPAND
 static void
-alt_expand(XPtrV *wp, char *start, char *exp_start, char *end, int fdo)
+alt_expand(wp, start, exp_start, end, fdo)
+	XPtrV *wp;
+	char *start, *exp_start;
+	char *end;
+	int fdo;
 {
 	int UNINITIALIZED(count);
 	char *brace_start, *brace_end, *UNINITIALIZED(comma);
@@ -1369,4 +1401,3 @@ alt_expand(XPtrV *wp, char *start, char *exp_start, char *end, int fdo)
 	return;
 }
 #endif /* BRACE_EXPAND */
-

--- a/bin/ksh/eval.c
+++ b/bin/ksh/eval.c
@@ -64,9 +64,7 @@ static void	alt_expand ARGS((XPtrV *wp, char *start, char *exp_start,
 
 /* compile and expand word */
 char *
-substitute(cp, f)
-	const char *cp;
-	int f;
+substitute(const char *cp, int f)
 {
 	struct source *s, *sold;
 
@@ -85,9 +83,7 @@ substitute(cp, f)
  * expand arg-list
  */
 char **
-eval(ap, f)
-	register char **ap;
-	int f;
+eval(register char **ap, int f)
 {
 	XPtrV w;
 
@@ -112,9 +108,7 @@ eval(ap, f)
  * expand string
  */
 char *
-evalstr(cp, f)
-	char *cp;
-	int f;
+evalstr(char *cp, int f)
 {
 	XPtrV w;
 
@@ -130,9 +124,7 @@ evalstr(cp, f)
  * used from iosetup to expand redirection files
  */
 char *
-evalonestr(cp, f)
-	register char *cp;
-	int f;
+evalonestr(register char *cp, int f)
 {
 	XPtrV w;
 
@@ -164,11 +156,12 @@ typedef struct SubType {
 	struct SubType *next;	/* poped type (to avoid re-allocating) */
 } SubType;
 
+/* cp - input word
+ * wp - output words
+ * f - DO* flags
+ */
 void
-expand(cp, wp, f)
-	char *cp;		/* input word */
-	register XPtrV *wp;	/* output words */
-	int f;			/* DO* flags */
+expand(char *cp, register XPtrV *wp, int f)
 {
 	register int UNINITIALIZED(c);
 	register int type;	/* expansion type */
@@ -682,7 +675,7 @@ expand(cp, wp, f)
 				quote &= ~2; /* undo temporary */
 
 			if (make_magic) {
-				make_magic = 0;
+			 	make_magic = 0;
 				fdo |= DOMAGIC_ | (f & DOGLOB);
 				*dp++ = MAGIC;
 			} else if (ISMAGIC(c)) {
@@ -697,14 +690,11 @@ expand(cp, wp, f)
 
 /*
  * Prepare to generate the string returned by ${} substitution.
+ * stypep: becomes qualifier type
+ * slenp: " " len (=, :=, etc) valid iff *stypep != 0
  */
 static int
-varsub(xp, sp, word, stypep, slenp)
-	Expand *xp;
-	char *sp;
-	char *word;
-	int *stypep;	/* becomes qualifier type */
-	int *slenp;	/* " " len (=, :=, etc.) valid iff *stypep != 0 */
+varsub(Expand *xp, char *sp, char *word, int *stypep, int *slenp)
 {
 	int c;
 	int state;	/* next state: XBASE, XARG, XSUB, XNULLSUB */
@@ -850,9 +840,7 @@ varsub(xp, sp, word, stypep, slenp)
  * Run the command in $(...) and read its output.
  */
 static int
-comsub(xp, cp)
-	register Expand *xp;
-	char *cp;
+comsub(register Expand *xp, char *cp)
 {
 	Source *s, *sold;
 	register struct op *t;
@@ -905,10 +893,7 @@ comsub(xp, cp)
  */
 
 static char *
-trimsub(str, pat, how)
-	register char *str;
-	char *pat;
-	int how;
+trimsub(register char *str, char *pat, int how)
 {
 	register char *end = strchr(str, 0);
 	register char *p, c;
@@ -958,10 +943,7 @@ trimsub(str, pat, how)
 
 /* XXX cp not const 'cause slashes are temporarily replaced with nulls... */
 static void
-glob(cp, wp, markdirs)
-	char *cp;
-	register XPtrV *wp;
-	int markdirs;
+glob(char *cp, register XPtrV *wp, int markdirs)
 {
 	int oldsize = XPsize(*wp);
 
@@ -981,10 +963,7 @@ glob(cp, wp, markdirs)
  * the number of matches found.
  */
 int
-glob_str(cp, wp, markdirs)
-	char *cp;
-	XPtrV *wp;
-	int markdirs;
+glob_str(char *cp, XPtrV *wp, int markdirs)
 {
 	int oldsize = XPsize(*wp);
 	XString xs;
@@ -997,13 +976,15 @@ glob_str(cp, wp, markdirs)
 	return XPsize(*wp) - oldsize;
 }
 
+/*
+ * xs - dest string
+ * xpp - prt to dest end
+ * sp - source path
+ * wp - output list
+ * check - GF_* paths
+ */
 static void
-globit(xs, xpp, sp, wp, check)
-	XString *xs;		/* dest string */
-	char **xpp;		/* ptr to dest end */
-	char *sp;		/* source path */
-	register XPtrV *wp;	/* output list */
-	int check;		/* GF_* flags */
+globit(XString *xs, char **xpp, char *sp, register XPtrV *wp, int check)
 {
 	register char *np;	/* next source component */
 	char *xp = *xpp;
@@ -1187,10 +1168,7 @@ copy_non_glob(xs, xpp, p)
 
 /* remove MAGIC from string */
 char *
-debunk(dp, sp, dlen)
-	char *dp;
-	const char *sp;
-	size_t dlen;
+debunk(char *dp, const char *sp, size_t dlen)
 {
 	char *d, *s;
 
@@ -1220,11 +1198,7 @@ debunk(dp, sp, dlen)
  * past the name, otherwise returns 0.
  */
 static char *
-maybe_expand_tilde(p, dsp, dpp, isassign)
-	char *p;
-	XString *dsp;
-	char **dpp;
-	int isassign;
+maybe_expand_tilde(char *p, XString *dsp, char **dpp, int isassign)
 {
 	XString ts;
 	char *dp = *dpp;
@@ -1262,8 +1236,7 @@ maybe_expand_tilde(p, dsp, dpp, isassign)
  */
 
 static char *
-tilde(cp)
-	char *cp;
+tilde(char *cp)
 {
 	char *dp;
 
@@ -1289,8 +1262,7 @@ tilde(cp)
  */
 
 static char *
-homedir(name)
-	char *name;
+homedir(char *name)
 {
 	register struct tbl *ap;
 
@@ -1322,11 +1294,7 @@ homedir(name)
 
 #ifdef BRACE_EXPAND
 static void
-alt_expand(wp, start, exp_start, end, fdo)
-	XPtrV *wp;
-	char *start, *exp_start;
-	char *end;
-	int fdo;
+alt_expand(XPtrV *wp, char *start, char *exp_start, char *end, int fdo)
 {
 	int UNINITIALIZED(count);
 	char *brace_start, *brace_end, *UNINITIALIZED(comma);
@@ -1401,3 +1369,4 @@ alt_expand(wp, start, exp_start, end, fdo)
 	return;
 }
 #endif /* BRACE_EXPAND */
+

--- a/bin/ksh/exec.c
+++ b/bin/ksh/exec.c
@@ -58,7 +58,8 @@ static char clexec_tab[MAXFD+1];
  * we now use this function always.
  */
 int
-fd_clexec(int fd)
+fd_clexec(fd)
+    int fd;
 {
 #ifndef F_SETFD
 	if (fd >= 0 && fd < sizeof(clexec_tab)) {
@@ -76,7 +77,9 @@ fd_clexec(int fd)
  * execute command tree
  */
 int
-execute(struct op * volatile t, volatile int flags)
+execute(t, flags)
+	struct op * volatile t;
+	volatile int flags;	/* if XEXEC don't fork */
 {
 	int i;
 	volatile int rv = 0;
@@ -447,7 +450,11 @@ execute(struct op * volatile t, volatile int flags)
  */
 
 static int
-comexec(struct op *t, struct tbl *volatile tp, register char **ap, int volatile flags)
+comexec(t, tp, ap, flags)
+	struct op *t;
+	struct tbl *volatile tp;
+	register char **ap;
+	int volatile flags;
 {
 	int i;
 	int leave = LLEAVE;
@@ -749,7 +756,9 @@ comexec(struct op *t, struct tbl *volatile tp, register char **ap, int volatile 
 }
 
 static void
-scriptexec(register struct op *tp, register char **ap)
+scriptexec(tp, ap)
+	register struct op *tp;
+	register char **ap;
 {
 	char *shellv;
 
@@ -861,7 +870,8 @@ scriptexec(register struct op *tp, register char **ap)
 }
 
 int
-shcomexec(register char **wp)
+shcomexec(wp)
+	register char **wp;
 {
 	register struct tbl *tp;
 
@@ -876,7 +886,10 @@ shcomexec(register char **wp)
  * is created if none is found.
  */
 struct tbl *
-findfunc(const char *name, unsigned int h, int create)
+findfunc(name, h, create)
+	const char *name;
+	unsigned int h;
+	int create;
 {
 	struct block *l;
 	struct tbl *tp = (struct tbl *) 0;
@@ -901,7 +914,9 @@ findfunc(const char *name, unsigned int h, int create)
  * function did not exist, returns 0 otherwise.
  */
 int
-define(const char *name, struct op *t)
+define(name, t)
+	const char *name;
+	struct op *t;
 {
 	struct tbl *tp;
 	int was_set = 0;
@@ -944,7 +959,9 @@ define(const char *name, struct op *t)
  * add builtin
  */
 void
-builtin(const char *name, int (*func) ARGS((char **)))
+builtin(name, func)
+	const char *name;
+	int (*func) ARGS((char **));
 {
 	register struct tbl *tp;
 	Tflag flag;
@@ -970,10 +987,11 @@ builtin(const char *name, int (*func) ARGS((char **)))
 /*
  * find command
  * either function, hashed command, or built-in (in that order)
- * flags is FC_*
  */
 struct tbl *
-findcom(const char *name, int flags)
+findcom(name, flags)
+	const char *name;
+	int	flags;		/* FC_* */
 {
 	static struct tbl temp;
 	unsigned int h = hash(name);
@@ -1073,10 +1091,10 @@ findcom(const char *name, int flags)
 
 /*
  * flush executable commands with relative paths
- * all - just relative or all
  */
 void
-flushcom(int all)
+flushcom(all)
+	int all;		/* just relative or all */
 {
 	struct tbl *tp;
 	struct tstate ts;
@@ -1091,11 +1109,12 @@ flushcom(int all)
 		}
 }
 
-/* Check if path is something we want to find.  Returns -1 for failure.
- * errnop is set if canidate found, but not suitable
- */
+/* Check if path is something we want to find.  Returns -1 for failure. */
 int
-search_access(const char *pathx, int mode, int *errnop)
+search_access(pathx, mode, errnop)
+	const char *pathx;
+	int mode;
+	int *errnop;		/* set if candidate found, but not suitable */
 {
 #ifndef OS2
 	int ret, err = 0;
@@ -1161,9 +1180,11 @@ search_access(const char *pathx, int mode, int *errnop)
 }
 
 #ifdef OS2
-/* errnop is set if candidate found, but not suitable */
 static int
-search_access1(const char *pathx, int mode, int *errnop)
+search_access1(pathx, mode, errnop)
+	const char *pathx;
+	int mode;
+	int *errnop;		/* set if candidate found, but not suitable */
 {
 	int ret, err = 0;
 	struct stat statb;
@@ -1185,11 +1206,13 @@ search_access1(const char *pathx, int mode, int *errnop)
 
 /*
  * search for command with PATH
- * mode == R_OK or X_OK
- * errnop is set if candidate found, but not suitable
  */
 char *
-search(const char *name, const char *pathx, int mode, int *errnop)
+search(name, pathx, mode, errnop)
+	const char *name;
+	const char *pathx;
+	int mode;		/* R_OK or X_OK */
+	int *errnop;		/* set if candidate found, but not suitable */
 {
 	const char *sp, *p;
 	char *xp;
@@ -1255,7 +1278,9 @@ search(const char *name, const char *pathx, int mode, int *errnop)
 }
 
 static int
-call_builtin(struct tbl *tp, char **wp)
+call_builtin(tp, wp)
+	struct tbl *tp;
+	char **wp;
 {
 	int rv;
 
@@ -1276,7 +1301,9 @@ call_builtin(struct tbl *tp, char **wp)
  * set up redirection, saving old fd's in e->savefd
  */
 static int
-iosetup(register struct ioword *iop, struct tbl *tp)
+iosetup(iop, tp)
+	register struct ioword *iop;
+	struct tbl *tp;
 {
 	register int u = -1;
 	char *cp = iop->name;
@@ -1420,7 +1447,9 @@ iosetup(register struct ioword *iop, struct tbl *tp)
  * if unquoted here, expand here temp file into second temp file.
  */
 static int
-herein(const char *content, int sub)
+herein(content, sub)
+	const char *content;
+	int sub;
 {
 	volatile int fd = -1;
 	struct source *s, *volatile osource;
@@ -1487,7 +1516,9 @@ herein(const char *content, int sub)
  *	print the args in column form - assuming that we can
  */
 static char *
-do_selectargs(register char **ap, bool_t print_menu)
+do_selectargs(ap, print_menu)
+	register char **ap;
+	bool_t print_menu;
 {
 	static const char *const read_args[] = {
 					"read", "-r", "REPLY", (char *) 0
@@ -1528,7 +1559,11 @@ static char *select_fmt_entry ARGS((void *arg, int i, char *buf, int buflen));
 
 /* format a single select menu item */
 static char *
-select_fmt_entry(void *arg, int i, char *buf, int buflen)
+select_fmt_entry(arg, i, buf, buflen)
+	void *arg;
+	int i;
+	char *buf;
+	int buflen;
 {
 	struct select_menu_info *smi = (struct select_menu_info *) arg;
 
@@ -1541,7 +1576,8 @@ select_fmt_entry(void *arg, int i, char *buf, int buflen)
  *	print a select style menu
  */
 int
-pr_menu(char *const *ap)
+pr_menu(ap)
+	char *const *ap;
 {
 	struct select_menu_info smi;
 	char *const *pp;
@@ -1584,14 +1620,19 @@ pr_menu(char *const *ap)
 static char *plain_fmt_entry ARGS((void *arg, int i, char *buf, int buflen));
 
 static char *
-plain_fmt_entry(void *arg, int i, char *buf, int buflen)
+plain_fmt_entry(arg, i, buf, buflen)
+	void *arg;
+	int i;
+	char *buf;
+	int buflen;
 {
 	shf_snprintf(buf, buflen, "%s", ((char *const *)arg)[i]);
 	return buf;
 }
 
 int
-pr_list(char *const *ap)
+pr_list(ap)
+	char *const *ap;
 {
 	char *const *pp;
 	int nwidth;
@@ -1621,7 +1662,9 @@ extern const char db_close[];
  * TM_UNOP and TM_BINOP, the returned value is a Test_op).
  */
 static int
-dbteste_isa(Test_env *te, Test_meta meta)
+dbteste_isa(te, meta)
+	Test_env *te;
+	Test_meta meta;
 {
 	int ret = 0;
 	int uqword;
@@ -1660,7 +1703,10 @@ dbteste_isa(Test_env *te, Test_meta meta)
 }
 
 static const char *
-dbteste_getopnd(Test_env *te, Test_op op, int do_eval)
+dbteste_getopnd(te, op, do_eval)
+	Test_env *te;
+	Test_op op;
+	int do_eval;
 {
 	char *s = *te->pos.wp;
 
@@ -1681,17 +1727,23 @@ dbteste_getopnd(Test_env *te, Test_op op, int do_eval)
 }
 
 static int
-dbteste_eval(Test_env *te, Test_op op, const char *opnd1, const char *opnd2,
-			 int do_eval)
+dbteste_eval(te, op, opnd1, opnd2, do_eval)
+	Test_env *te;
+	Test_op op;
+	const char *opnd1;
+	const char *opnd2;
+	int do_eval;
 {
 	return test_eval(te, op, opnd1, opnd2, do_eval);
 }
 
 static void
-dbteste_error(Test_env *te, int offset, const char *msg)
+dbteste_error(te, offset, msg)
+	Test_env *te;
+	int offset;
+	const char *msg;
 {
 	te->flags |= TEF_ERROR;
 	internal_errorf(0, "dbteste_error: %s (offset %d)", msg, offset);
 }
 #endif /* KSH */
-

--- a/bin/ksh/exec.c
+++ b/bin/ksh/exec.c
@@ -58,8 +58,7 @@ static char clexec_tab[MAXFD+1];
  * we now use this function always.
  */
 int
-fd_clexec(fd)
-    int fd;
+fd_clexec(int fd)
 {
 #ifndef F_SETFD
 	if (fd >= 0 && fd < sizeof(clexec_tab)) {
@@ -77,9 +76,7 @@ fd_clexec(fd)
  * execute command tree
  */
 int
-execute(t, flags)
-	struct op * volatile t;
-	volatile int flags;	/* if XEXEC don't fork */
+execute(struct op * volatile t, volatile int flags)
 {
 	int i;
 	volatile int rv = 0;
@@ -450,11 +447,7 @@ execute(t, flags)
  */
 
 static int
-comexec(t, tp, ap, flags)
-	struct op *t;
-	struct tbl *volatile tp;
-	register char **ap;
-	int volatile flags;
+comexec(struct op *t, struct tbl *volatile tp, register char **ap, int volatile flags)
 {
 	int i;
 	int leave = LLEAVE;
@@ -756,9 +749,7 @@ comexec(t, tp, ap, flags)
 }
 
 static void
-scriptexec(tp, ap)
-	register struct op *tp;
-	register char **ap;
+scriptexec(register struct op *tp, register char **ap)
 {
 	char *shellv;
 
@@ -870,8 +861,7 @@ scriptexec(tp, ap)
 }
 
 int
-shcomexec(wp)
-	register char **wp;
+shcomexec(register char **wp)
 {
 	register struct tbl *tp;
 
@@ -886,10 +876,7 @@ shcomexec(wp)
  * is created if none is found.
  */
 struct tbl *
-findfunc(name, h, create)
-	const char *name;
-	unsigned int h;
-	int create;
+findfunc(const char *name, unsigned int h, int create)
 {
 	struct block *l;
 	struct tbl *tp = (struct tbl *) 0;
@@ -914,9 +901,7 @@ findfunc(name, h, create)
  * function did not exist, returns 0 otherwise.
  */
 int
-define(name, t)
-	const char *name;
-	struct op *t;
+define(const char *name, struct op *t)
 {
 	struct tbl *tp;
 	int was_set = 0;
@@ -959,9 +944,7 @@ define(name, t)
  * add builtin
  */
 void
-builtin(name, func)
-	const char *name;
-	int (*func) ARGS((char **));
+builtin(const char *name, int (*func) ARGS((char **)))
 {
 	register struct tbl *tp;
 	Tflag flag;
@@ -987,11 +970,10 @@ builtin(name, func)
 /*
  * find command
  * either function, hashed command, or built-in (in that order)
+ * flags is FC_*
  */
 struct tbl *
-findcom(name, flags)
-	const char *name;
-	int	flags;		/* FC_* */
+findcom(const char *name, int flags)
 {
 	static struct tbl temp;
 	unsigned int h = hash(name);
@@ -1091,10 +1073,10 @@ findcom(name, flags)
 
 /*
  * flush executable commands with relative paths
+ * all - just relative or all
  */
 void
-flushcom(all)
-	int all;		/* just relative or all */
+flushcom(int all)
 {
 	struct tbl *tp;
 	struct tstate ts;
@@ -1109,12 +1091,11 @@ flushcom(all)
 		}
 }
 
-/* Check if path is something we want to find.  Returns -1 for failure. */
+/* Check if path is something we want to find.  Returns -1 for failure.
+ * errnop is set if canidate found, but not suitable
+ */
 int
-search_access(pathx, mode, errnop)
-	const char *pathx;
-	int mode;
-	int *errnop;		/* set if candidate found, but not suitable */
+search_access(const char *pathx, int mode, int *errnop)
 {
 #ifndef OS2
 	int ret, err = 0;
@@ -1180,11 +1161,9 @@ search_access(pathx, mode, errnop)
 }
 
 #ifdef OS2
+/* errnop is set if candidate found, but not suitable */
 static int
-search_access1(pathx, mode, errnop)
-	const char *pathx;
-	int mode;
-	int *errnop;		/* set if candidate found, but not suitable */
+search_access1(const char *pathx, int mode, int *errnop)
 {
 	int ret, err = 0;
 	struct stat statb;
@@ -1206,13 +1185,11 @@ search_access1(pathx, mode, errnop)
 
 /*
  * search for command with PATH
+ * mode == R_OK or X_OK
+ * errnop is set if candidate found, but not suitable
  */
 char *
-search(name, pathx, mode, errnop)
-	const char *name;
-	const char *pathx;
-	int mode;		/* R_OK or X_OK */
-	int *errnop;		/* set if candidate found, but not suitable */
+search(const char *name, const char *pathx, int mode, int *errnop)
 {
 	const char *sp, *p;
 	char *xp;
@@ -1278,9 +1255,7 @@ search(name, pathx, mode, errnop)
 }
 
 static int
-call_builtin(tp, wp)
-	struct tbl *tp;
-	char **wp;
+call_builtin(struct tbl *tp, char **wp)
 {
 	int rv;
 
@@ -1301,9 +1276,7 @@ call_builtin(tp, wp)
  * set up redirection, saving old fd's in e->savefd
  */
 static int
-iosetup(iop, tp)
-	register struct ioword *iop;
-	struct tbl *tp;
+iosetup(register struct ioword *iop, struct tbl *tp)
 {
 	register int u = -1;
 	char *cp = iop->name;
@@ -1447,9 +1420,7 @@ iosetup(iop, tp)
  * if unquoted here, expand here temp file into second temp file.
  */
 static int
-herein(content, sub)
-	const char *content;
-	int sub;
+herein(const char *content, int sub)
 {
 	volatile int fd = -1;
 	struct source *s, *volatile osource;
@@ -1516,9 +1487,7 @@ herein(content, sub)
  *	print the args in column form - assuming that we can
  */
 static char *
-do_selectargs(ap, print_menu)
-	register char **ap;
-	bool_t print_menu;
+do_selectargs(register char **ap, bool_t print_menu)
 {
 	static const char *const read_args[] = {
 					"read", "-r", "REPLY", (char *) 0
@@ -1559,11 +1528,7 @@ static char *select_fmt_entry ARGS((void *arg, int i, char *buf, int buflen));
 
 /* format a single select menu item */
 static char *
-select_fmt_entry(arg, i, buf, buflen)
-	void *arg;
-	int i;
-	char *buf;
-	int buflen;
+select_fmt_entry(void *arg, int i, char *buf, int buflen)
 {
 	struct select_menu_info *smi = (struct select_menu_info *) arg;
 
@@ -1576,8 +1541,7 @@ select_fmt_entry(arg, i, buf, buflen)
  *	print a select style menu
  */
 int
-pr_menu(ap)
-	char *const *ap;
+pr_menu(char *const *ap)
 {
 	struct select_menu_info smi;
 	char *const *pp;
@@ -1620,19 +1584,14 @@ pr_menu(ap)
 static char *plain_fmt_entry ARGS((void *arg, int i, char *buf, int buflen));
 
 static char *
-plain_fmt_entry(arg, i, buf, buflen)
-	void *arg;
-	int i;
-	char *buf;
-	int buflen;
+plain_fmt_entry(void *arg, int i, char *buf, int buflen)
 {
 	shf_snprintf(buf, buflen, "%s", ((char *const *)arg)[i]);
 	return buf;
 }
 
 int
-pr_list(ap)
-	char *const *ap;
+pr_list(char *const *ap)
 {
 	char *const *pp;
 	int nwidth;
@@ -1662,9 +1621,7 @@ extern const char db_close[];
  * TM_UNOP and TM_BINOP, the returned value is a Test_op).
  */
 static int
-dbteste_isa(te, meta)
-	Test_env *te;
-	Test_meta meta;
+dbteste_isa(Test_env *te, Test_meta meta)
 {
 	int ret = 0;
 	int uqword;
@@ -1703,10 +1660,7 @@ dbteste_isa(te, meta)
 }
 
 static const char *
-dbteste_getopnd(te, op, do_eval)
-	Test_env *te;
-	Test_op op;
-	int do_eval;
+dbteste_getopnd(Test_env *te, Test_op op, int do_eval)
 {
 	char *s = *te->pos.wp;
 
@@ -1727,23 +1681,17 @@ dbteste_getopnd(te, op, do_eval)
 }
 
 static int
-dbteste_eval(te, op, opnd1, opnd2, do_eval)
-	Test_env *te;
-	Test_op op;
-	const char *opnd1;
-	const char *opnd2;
-	int do_eval;
+dbteste_eval(Test_env *te, Test_op op, const char *opnd1, const char *opnd2,
+			 int do_eval)
 {
 	return test_eval(te, op, opnd1, opnd2, do_eval);
 }
 
 static void
-dbteste_error(te, offset, msg)
-	Test_env *te;
-	int offset;
-	const char *msg;
+dbteste_error(Test_env *te, int offset, const char *msg)
 {
 	te->flags |= TEF_ERROR;
 	internal_errorf(0, "dbteste_error: %s (offset %d)", msg, offset);
 }
 #endif /* KSH */
+

--- a/bin/ksh/expand.h
+++ b/bin/ksh/expand.h
@@ -107,4 +107,3 @@ typedef struct XPtrV {
 					 sizeofN(void*, XPsize(x)), ATEMP)
 
 #define	XPfree(x)	afree((void*) (x).beg, ATEMP)
-

--- a/bin/ksh/expand.h
+++ b/bin/ksh/expand.h
@@ -107,3 +107,4 @@ typedef struct XPtrV {
 					 sizeofN(void*, XPsize(x)), ATEMP)
 
 #define	XPfree(x)	afree((void*) (x).beg, ATEMP)
+

--- a/bin/ksh/expr.c
+++ b/bin/ksh/expr.c
@@ -149,7 +149,10 @@ static struct tbl *intvar   ARGS((Expr_state *es, struct tbl *vp));
  * parse and evaluate expression
  */
 int
-evaluate(const char *expr, long *rval, int error_ok)
+evaluate(expr, rval, error_ok)
+	const char *expr;
+	long *rval;
+	int error_ok;
 {
 	struct tbl v;
 	int ret;
@@ -165,7 +168,10 @@ evaluate(const char *expr, long *rval, int error_ok)
  * parse and evaluate expression, storing result in vp.
  */
 int
-v_evaluate(struct tbl *vp, const char *expr, volatile int error_ok)
+v_evaluate(vp, expr, error_ok)
+	struct tbl *vp;
+	const char *expr;
+	volatile int error_ok;
 {
 	struct tbl *v;
 	Expr_state curstate;
@@ -217,7 +223,10 @@ v_evaluate(struct tbl *vp, const char *expr, volatile int error_ok)
 }
 
 static void
-evalerr(Expr_state *es, enum error_type type, const char *str)
+evalerr(es, type, str)
+	Expr_state *es;
+	enum error_type type;
+	const char *str;
 {
 	char tbuf[2];
 	const char *s;
@@ -273,7 +282,9 @@ evalerr(Expr_state *es, enum error_type type, const char *str)
 }
 
 static struct tbl *
-evalexpr(Expr_state *es, enum prec prec)
+evalexpr(es, prec)
+	Expr_state *es;
+	enum prec prec;
 {
 	struct tbl *vl, UNINITIALIZED(*vr), *vasn;
 	enum token op;
@@ -452,7 +463,8 @@ evalexpr(Expr_state *es, enum prec prec)
 }
 
 static void
-token(Expr_state *es)
+token(es)
+	Expr_state *es;
 {
 	const char *cp;
 	int c;
@@ -525,7 +537,11 @@ token(Expr_state *es)
 
 /* Do a ++ or -- operation */
 static struct tbl *
-do_ppmm(Expr_state *es, enum token op, struct tbl *vasn, bool_t is_prefix)
+do_ppmm(es, op, vasn, is_prefix)
+	Expr_state *es;
+	enum token op;
+	struct tbl *vasn;
+	bool_t is_prefix;
 {
 	struct tbl *vl;
 	int oval;
@@ -545,7 +561,10 @@ do_ppmm(Expr_state *es, enum token op, struct tbl *vasn, bool_t is_prefix)
 }
 
 static void
-assign_check(Expr_state *es, enum token op, struct tbl *vasn)
+assign_check(es, op, vasn)
+	Expr_state *es;
+	enum token op;
+	struct tbl *vasn;
 {
 	if (vasn->name[0] == '\0' && !(vasn->flag & EXPRLVALUE))
 		evalerr(es, ET_LVALUE, opinfo[(int) op].name);
@@ -554,7 +573,7 @@ assign_check(Expr_state *es, enum token op, struct tbl *vasn)
 }
 
 static struct tbl *
-tempvar(void)
+tempvar()
 {
 	register struct tbl *vp;
 
@@ -569,7 +588,9 @@ tempvar(void)
 
 /* cast (string) variable to temporary integer variable */
 static struct tbl *
-intvar(Expr_state *es, struct tbl *vp)
+intvar(es, vp)
+	Expr_state *es;
+	struct tbl *vp;
 {
 	struct tbl *vq;
 
@@ -590,4 +611,3 @@ intvar(Expr_state *es, struct tbl *vp)
 	}
 	return vq;
 }
-

--- a/bin/ksh/expr.c
+++ b/bin/ksh/expr.c
@@ -149,10 +149,7 @@ static struct tbl *intvar   ARGS((Expr_state *es, struct tbl *vp));
  * parse and evaluate expression
  */
 int
-evaluate(expr, rval, error_ok)
-	const char *expr;
-	long *rval;
-	int error_ok;
+evaluate(const char *expr, long *rval, int error_ok)
 {
 	struct tbl v;
 	int ret;
@@ -168,10 +165,7 @@ evaluate(expr, rval, error_ok)
  * parse and evaluate expression, storing result in vp.
  */
 int
-v_evaluate(vp, expr, error_ok)
-	struct tbl *vp;
-	const char *expr;
-	volatile int error_ok;
+v_evaluate(struct tbl *vp, const char *expr, volatile int error_ok)
 {
 	struct tbl *v;
 	Expr_state curstate;
@@ -223,10 +217,7 @@ v_evaluate(vp, expr, error_ok)
 }
 
 static void
-evalerr(es, type, str)
-	Expr_state *es;
-	enum error_type type;
-	const char *str;
+evalerr(Expr_state *es, enum error_type type, const char *str)
 {
 	char tbuf[2];
 	const char *s;
@@ -282,9 +273,7 @@ evalerr(es, type, str)
 }
 
 static struct tbl *
-evalexpr(es, prec)
-	Expr_state *es;
-	enum prec prec;
+evalexpr(Expr_state *es, enum prec prec)
 {
 	struct tbl *vl, UNINITIALIZED(*vr), *vasn;
 	enum token op;
@@ -463,8 +452,7 @@ evalexpr(es, prec)
 }
 
 static void
-token(es)
-	Expr_state *es;
+token(Expr_state *es)
 {
 	const char *cp;
 	int c;
@@ -537,11 +525,7 @@ token(es)
 
 /* Do a ++ or -- operation */
 static struct tbl *
-do_ppmm(es, op, vasn, is_prefix)
-	Expr_state *es;
-	enum token op;
-	struct tbl *vasn;
-	bool_t is_prefix;
+do_ppmm(Expr_state *es, enum token op, struct tbl *vasn, bool_t is_prefix)
 {
 	struct tbl *vl;
 	int oval;
@@ -561,10 +545,7 @@ do_ppmm(es, op, vasn, is_prefix)
 }
 
 static void
-assign_check(es, op, vasn)
-	Expr_state *es;
-	enum token op;
-	struct tbl *vasn;
+assign_check(Expr_state *es, enum token op, struct tbl *vasn)
 {
 	if (vasn->name[0] == '\0' && !(vasn->flag & EXPRLVALUE))
 		evalerr(es, ET_LVALUE, opinfo[(int) op].name);
@@ -573,7 +554,7 @@ assign_check(es, op, vasn)
 }
 
 static struct tbl *
-tempvar()
+tempvar(void)
 {
 	register struct tbl *vp;
 
@@ -588,9 +569,7 @@ tempvar()
 
 /* cast (string) variable to temporary integer variable */
 static struct tbl *
-intvar(es, vp)
-	Expr_state *es;
-	struct tbl *vp;
+intvar(Expr_state *es, struct tbl *vp)
 {
 	struct tbl *vq;
 
@@ -611,3 +590,4 @@ intvar(es, vp)
 	}
 	return vq;
 }
+

--- a/bin/ksh/history.c
+++ b/bin/ksh/history.c
@@ -80,7 +80,8 @@ static Source	*hist_source;
 
 
 int
-c_fc(char **wp)
+c_fc(wp)
+	char **wp;
 {
 	struct shf *shf;
 	struct temp UNINITIALIZED(*tf);
@@ -297,7 +298,8 @@ c_fc(char **wp)
 
 /* Save cmd in history, execute cmd (cmd gets trashed) */
 static int
-hist_execute(char *cmd)
+hist_execute(cmd)
+	char *cmd;
 {
 	Source *sold;
 	int ret;
@@ -337,7 +339,11 @@ hist_execute(char *cmd)
 }
 
 static int
-hist_replace(char **hp, const char *pat, const char *rep, int globalv)
+hist_replace(hp, pat, rep, globalv)
+	char **hp;
+	const char *pat;
+	const char *rep;
+	int globalv;
 {
 	char *line;
 
@@ -382,7 +388,10 @@ hist_replace(char **hp, const char *pat, const char *rep, int globalv)
  * pattern is a number or string
  */
 static char **
-hist_get(const char *str, int approx, int allow_cur)
+hist_get(str, approx, allow_cur)
+	const char *str;
+	int approx;
+	int allow_cur;
 {
 	char **hp = (char **) 0;
 	int n;
@@ -423,7 +432,8 @@ hist_get(const char *str, int approx, int allow_cur)
 
 /* Return a pointer to the newest command in the history */
 static char **
-hist_get_newest(int allow_cur)
+hist_get_newest(allow_cur)
+	int allow_cur;
 {
 	if (histptr < histlist || (!allow_cur && histptr == histlist)) {
 		bi_errorf("no history (yet)");
@@ -436,7 +446,7 @@ hist_get_newest(int allow_cur)
 
 /* Return a pointer to the newest command in the history */
 static char **
-hist_get_oldest(void)
+hist_get_oldest()
 {
 	if (histptr <= histlist) {
 		bi_errorf("no history (yet)");
@@ -449,7 +459,7 @@ hist_get_oldest(void)
 /* Back up over last histsave */
 /******************************/
 static void
-histbackup(void)
+histbackup()
 {
 	static int last_line = -1;
 
@@ -465,19 +475,20 @@ histbackup(void)
  * Return the current position.
  */
 char **
-histpos(void)
+histpos()
 {
 	return current;
 }
 
 int
-histN(void)
+histN()
 {
 	return curpos;
 }
 
 int
-histnum(int n)
+histnum(n)
+	int	n;
 {
 	int	last = histptr - histlist;
 
@@ -498,7 +509,11 @@ histnum(int n)
  * direction.
  */
 int
-findhist(int start, int fwd, const char *str, int anchored)
+findhist(start, fwd, str, anchored)
+	int	start;
+	int	fwd;
+	const char  *str;
+	int	anchored;
 {
 	char	**hp;
 	int	maxhist = histptr - histlist;
@@ -522,7 +537,8 @@ findhist(int start, int fwd, const char *str, int anchored)
  *	this means reallocating the dataspace
  */
 void
-sethistsize(int n)
+sethistsize(n)
+	int n;
 {
 	if (n > 0 && n != histsize) {
 		int cursize = histptr - histlist;
@@ -546,7 +562,8 @@ sethistsize(int n)
  *	maintenance
  */
 void
-sethistfile(const char *name)
+sethistfile(name)
+	const char *name;
 {
 	/* if not started then nothing to do */
 	if (hstarted == 0)
@@ -585,7 +602,7 @@ sethistfile(const char *name)
  *	initialise the history vector
  */
 void
-init_histvec(void)
+init_histvec()
 {
 	if (histlist == NULL) {
 		histsize = HISTORYSIZE;
@@ -597,10 +614,12 @@ init_histvec(void)
 # ifdef EASY_HISTORY
 /*
  * save command in history
- * lno and dowrite are ignored for compability with COMPLEX_HISTORY
  */
 void
-histsave(int lno, const char *cmd, int dowrite)
+histsave(lno, cmd, dowrite)
+	int lno;	/* ignored (compatibility with COMPLEX_HISTORY) */
+	const char *cmd;
+	int dowrite;	/* ignored (compatibility with COMPLEX_HISTORY) */
 {
 	register char **hp = histptr;
 	char *cp;
@@ -624,7 +643,9 @@ histsave(int lno, const char *cmd, int dowrite)
  * commands
  */
 void
-histappend(const char *cmd, int nl_separate)
+histappend(cmd, nl_separate)
+	const char *cmd;
+	int	nl_separate;
 {
 	int	hlen, clen;
 	char	*p;
@@ -650,7 +671,8 @@ histappend(const char *cmd, int nl_separate)
  * to save its history.
  */
 void
-hist_init(Source *s)
+hist_init(s)
+	Source *s;
 {
 	char *f;
 	FILE *fh;
@@ -715,7 +737,7 @@ hist_init(Source *s)
  */
 
 void
-hist_finish(void)
+hist_finish()
 {
   static int once;
   int fd;
@@ -775,7 +797,10 @@ hist_finish(void)
  * save command in history
  */
 void
-histsave(int lno, const char *cmd, int dowrite)
+histsave(lno, cmd, dowrite)
+	int lno;
+	const char *cmd;
+	int dowrite;
 {
 	register char **hp;
 	char *c, *cp;
@@ -823,7 +848,8 @@ histsave(int lno, const char *cmd, int dowrite)
 # define COMMAND		0xff
 
 void
-hist_init(Source *s)
+hist_init(s)
+	Source *s;
 {
 	unsigned char	*base;
 	int	lines;
@@ -900,7 +926,9 @@ typedef enum state {
 } State;
 
 static int
-hist_count_lines(register unsigned char *base, register int bytes)
+hist_count_lines(base, bytes)
+	register unsigned char *base;
+	register int bytes;
 {
 	State state = shdr;
 	int lines = 0;
@@ -933,7 +961,9 @@ hist_count_lines(register unsigned char *base, register int bytes)
  *	Shrink the history file to histsize lines
  */
 static int
-hist_shrink(unsigned char *oldbase, int oldbytes)
+hist_shrink(oldbase, oldbytes)
+	unsigned char *oldbase;
+	int oldbytes;
 {
 	int fd;
 	char	nfile[1024];
@@ -985,7 +1015,10 @@ hist_shrink(unsigned char *oldbase, int oldbytes)
  *	return the pointer and the number of bytes left
  */
 static unsigned char *
-hist_skip_back(unsigned char *base, int *bytes, int no)
+hist_skip_back(base, bytes, no)
+	unsigned char *base;
+	int *bytes;
+	int no;
 {
 	register int lines = 0;
 	register unsigned char *ep;
@@ -1011,7 +1044,10 @@ hist_skip_back(unsigned char *base, int *bytes, int no)
  *	load the history structure from the stored data
  */
 static void
-histload(Source *s, register unsigned char *base, register int bytes)
+histload(s, base, bytes)
+	Source *s;
+	register unsigned char *base;
+	register int bytes;
 {
 	State state;
 	int	lno = 0;
@@ -1061,7 +1097,10 @@ histload(Source *s, register unsigned char *base, register int bytes)
  *	Insert a line into the history at a specified number
  */
 static void
-histinsert(Source *s, int lno, unsigned char *line)
+histinsert(s, lno, line)
+	Source *s;
+	int lno;
+	unsigned char *line;
 {
 	register char **hp;
 
@@ -1081,7 +1120,9 @@ histinsert(Source *s, int lno, unsigned char *line)
  *	and we should read those commands to update our history
  */
 static void
-writehistfile(int lno, char *cmd)
+writehistfile(lno, cmd)
+	int lno;
+	char *cmd;
 {
 	int	sizenow;
 	unsigned char	*base;
@@ -1137,7 +1178,7 @@ bad:
 }
 
 void
-hist_finish(void)
+hist_finish()
 {
 	(void) flock(histfd, LOCK_UN);
 	(void) close(histfd);
@@ -1148,7 +1189,8 @@ hist_finish(void)
  *	add magic to the history file
  */
 static int
-sprinkle(int fd)
+sprinkle(fd)
+	int fd;
 {
 	static unsigned char mag[] = { HMAGIC1, HMAGIC2 };
 
@@ -1160,21 +1202,24 @@ sprinkle(int fd)
 
 /* No history to be compiled in: dummy routines to avoid lots more ifdefs */
 void
-init_histvec(void)
+init_histvec()
 {
 }
 void
-hist_init(Source *s)
+hist_init(s)
+	Source *s;
 {
 }
 void
-hist_finish(void)
+hist_finish()
 {
 }
 void
-histsave(int lno, const char *cmd, int dowrite)
+histsave(lno, cmd, dowrite)
+	int lno;
+	const char *cmd;
+	int dowrite;
 {
 	errorf("history not enabled");
 }
 #endif /* HISTORY */
-

--- a/bin/ksh/history.c
+++ b/bin/ksh/history.c
@@ -80,8 +80,7 @@ static Source	*hist_source;
 
 
 int
-c_fc(wp)
-	char **wp;
+c_fc(char **wp)
 {
 	struct shf *shf;
 	struct temp UNINITIALIZED(*tf);
@@ -298,8 +297,7 @@ c_fc(wp)
 
 /* Save cmd in history, execute cmd (cmd gets trashed) */
 static int
-hist_execute(cmd)
-	char *cmd;
+hist_execute(char *cmd)
 {
 	Source *sold;
 	int ret;
@@ -339,11 +337,7 @@ hist_execute(cmd)
 }
 
 static int
-hist_replace(hp, pat, rep, globalv)
-	char **hp;
-	const char *pat;
-	const char *rep;
-	int globalv;
+hist_replace(char **hp, const char *pat, const char *rep, int globalv)
 {
 	char *line;
 
@@ -388,10 +382,7 @@ hist_replace(hp, pat, rep, globalv)
  * pattern is a number or string
  */
 static char **
-hist_get(str, approx, allow_cur)
-	const char *str;
-	int approx;
-	int allow_cur;
+hist_get(const char *str, int approx, int allow_cur)
 {
 	char **hp = (char **) 0;
 	int n;
@@ -432,8 +423,7 @@ hist_get(str, approx, allow_cur)
 
 /* Return a pointer to the newest command in the history */
 static char **
-hist_get_newest(allow_cur)
-	int allow_cur;
+hist_get_newest(int allow_cur)
 {
 	if (histptr < histlist || (!allow_cur && histptr == histlist)) {
 		bi_errorf("no history (yet)");
@@ -446,7 +436,7 @@ hist_get_newest(allow_cur)
 
 /* Return a pointer to the newest command in the history */
 static char **
-hist_get_oldest()
+hist_get_oldest(void)
 {
 	if (histptr <= histlist) {
 		bi_errorf("no history (yet)");
@@ -459,7 +449,7 @@ hist_get_oldest()
 /* Back up over last histsave */
 /******************************/
 static void
-histbackup()
+histbackup(void)
 {
 	static int last_line = -1;
 
@@ -475,20 +465,19 @@ histbackup()
  * Return the current position.
  */
 char **
-histpos()
+histpos(void)
 {
 	return current;
 }
 
 int
-histN()
+histN(void)
 {
 	return curpos;
 }
 
 int
-histnum(n)
-	int	n;
+histnum(int n)
 {
 	int	last = histptr - histlist;
 
@@ -509,11 +498,7 @@ histnum(n)
  * direction.
  */
 int
-findhist(start, fwd, str, anchored)
-	int	start;
-	int	fwd;
-	const char  *str;
-	int	anchored;
+findhist(int start, int fwd, const char *str, int anchored)
 {
 	char	**hp;
 	int	maxhist = histptr - histlist;
@@ -537,8 +522,7 @@ findhist(start, fwd, str, anchored)
  *	this means reallocating the dataspace
  */
 void
-sethistsize(n)
-	int n;
+sethistsize(int n)
 {
 	if (n > 0 && n != histsize) {
 		int cursize = histptr - histlist;
@@ -562,8 +546,7 @@ sethistsize(n)
  *	maintenance
  */
 void
-sethistfile(name)
-	const char *name;
+sethistfile(const char *name)
 {
 	/* if not started then nothing to do */
 	if (hstarted == 0)
@@ -602,7 +585,7 @@ sethistfile(name)
  *	initialise the history vector
  */
 void
-init_histvec()
+init_histvec(void)
 {
 	if (histlist == NULL) {
 		histsize = HISTORYSIZE;
@@ -614,12 +597,10 @@ init_histvec()
 # ifdef EASY_HISTORY
 /*
  * save command in history
+ * lno and dowrite are ignored for compability with COMPLEX_HISTORY
  */
 void
-histsave(lno, cmd, dowrite)
-	int lno;	/* ignored (compatibility with COMPLEX_HISTORY) */
-	const char *cmd;
-	int dowrite;	/* ignored (compatibility with COMPLEX_HISTORY) */
+histsave(int lno, const char *cmd, int dowrite)
 {
 	register char **hp = histptr;
 	char *cp;
@@ -643,9 +624,7 @@ histsave(lno, cmd, dowrite)
  * commands
  */
 void
-histappend(cmd, nl_separate)
-	const char *cmd;
-	int	nl_separate;
+histappend(const char *cmd, int nl_separate)
 {
 	int	hlen, clen;
 	char	*p;
@@ -671,8 +650,7 @@ histappend(cmd, nl_separate)
  * to save its history.
  */
 void
-hist_init(s)
-	Source *s;
+hist_init(Source *s)
 {
 	char *f;
 	FILE *fh;
@@ -737,7 +715,7 @@ hist_init(s)
  */
 
 void
-hist_finish()
+hist_finish(void)
 {
   static int once;
   int fd;
@@ -797,10 +775,7 @@ hist_finish()
  * save command in history
  */
 void
-histsave(lno, cmd, dowrite)
-	int lno;
-	const char *cmd;
-	int dowrite;
+histsave(int lno, const char *cmd, int dowrite)
 {
 	register char **hp;
 	char *c, *cp;
@@ -848,8 +823,7 @@ histsave(lno, cmd, dowrite)
 # define COMMAND		0xff
 
 void
-hist_init(s)
-	Source *s;
+hist_init(Source *s)
 {
 	unsigned char	*base;
 	int	lines;
@@ -926,9 +900,7 @@ typedef enum state {
 } State;
 
 static int
-hist_count_lines(base, bytes)
-	register unsigned char *base;
-	register int bytes;
+hist_count_lines(register unsigned char *base, register int bytes)
 {
 	State state = shdr;
 	int lines = 0;
@@ -961,9 +933,7 @@ hist_count_lines(base, bytes)
  *	Shrink the history file to histsize lines
  */
 static int
-hist_shrink(oldbase, oldbytes)
-	unsigned char *oldbase;
-	int oldbytes;
+hist_shrink(unsigned char *oldbase, int oldbytes)
 {
 	int fd;
 	char	nfile[1024];
@@ -1015,10 +985,7 @@ hist_shrink(oldbase, oldbytes)
  *	return the pointer and the number of bytes left
  */
 static unsigned char *
-hist_skip_back(base, bytes, no)
-	unsigned char *base;
-	int *bytes;
-	int no;
+hist_skip_back(unsigned char *base, int *bytes, int no)
 {
 	register int lines = 0;
 	register unsigned char *ep;
@@ -1044,10 +1011,7 @@ hist_skip_back(base, bytes, no)
  *	load the history structure from the stored data
  */
 static void
-histload(s, base, bytes)
-	Source *s;
-	register unsigned char *base;
-	register int bytes;
+histload(Source *s, register unsigned char *base, register int bytes)
 {
 	State state;
 	int	lno = 0;
@@ -1097,10 +1061,7 @@ histload(s, base, bytes)
  *	Insert a line into the history at a specified number
  */
 static void
-histinsert(s, lno, line)
-	Source *s;
-	int lno;
-	unsigned char *line;
+histinsert(Source *s, int lno, unsigned char *line)
 {
 	register char **hp;
 
@@ -1120,9 +1081,7 @@ histinsert(s, lno, line)
  *	and we should read those commands to update our history
  */
 static void
-writehistfile(lno, cmd)
-	int lno;
-	char *cmd;
+writehistfile(int lno, char *cmd)
 {
 	int	sizenow;
 	unsigned char	*base;
@@ -1178,7 +1137,7 @@ bad:
 }
 
 void
-hist_finish()
+hist_finish(void)
 {
 	(void) flock(histfd, LOCK_UN);
 	(void) close(histfd);
@@ -1189,8 +1148,7 @@ hist_finish()
  *	add magic to the history file
  */
 static int
-sprinkle(fd)
-	int fd;
+sprinkle(int fd)
 {
 	static unsigned char mag[] = { HMAGIC1, HMAGIC2 };
 
@@ -1202,24 +1160,21 @@ sprinkle(fd)
 
 /* No history to be compiled in: dummy routines to avoid lots more ifdefs */
 void
-init_histvec()
+init_histvec(void)
 {
 }
 void
-hist_init(s)
-	Source *s;
+hist_init(Source *s)
 {
 }
 void
-hist_finish()
+hist_finish(void)
 {
 }
 void
-histsave(lno, cmd, dowrite)
-	int lno;
-	const char *cmd;
-	int dowrite;
+histsave(int lno, const char *cmd, int dowrite)
 {
 	errorf("history not enabled");
 }
 #endif /* HISTORY */
+

--- a/bin/ksh/io.c
+++ b/bin/ksh/io.c
@@ -23,7 +23,13 @@ static int initio_done;
 
 /* A shell error occurred (eg, syntax error, etc.) */
 void
+#ifdef HAVE_PROTOTYPES
 errorf(const char *fmt, ...)
+#else
+errorf(fmt, va_alist)
+	const char *fmt;
+	va_dcl
+#endif
 {
 	va_list va;
 
@@ -42,7 +48,14 @@ errorf(const char *fmt, ...)
 
 /* like errorf(), but no unwind is done */
 void
+#ifdef HAVE_PROTOTYPES
 warningf(int fileline, const char *fmt, ...)
+#else
+warningf(fileline, fmt, va_alist)
+	int fileline;
+	const char *fmt;
+	va_dcl
+#endif
 {
 	va_list va;
 
@@ -58,7 +71,13 @@ warningf(int fileline, const char *fmt, ...)
  * (also unwinds environments for special builtins).
  */
 void
+#ifdef HAVE_PROTOTYPES
 bi_errorf(const char *fmt, ...)
+#else
+bi_errorf(fmt, va_alist)
+	const char *fmt;
+	va_dcl
+#endif
 {
 	va_list va;
 
@@ -89,7 +108,14 @@ bi_errorf(const char *fmt, ...)
 
 /* Called when something that shouldn't happen does */
 void
+#ifdef HAVE_PROTOTYPES
 internal_errorf(int jump, const char *fmt, ...)
+#else
+internal_errorf(jump, fmt, va_alist)
+	int jump;
+	const char *fmt;
+	va_dcl
+#endif
 {
 	va_list va;
 
@@ -106,7 +132,8 @@ internal_errorf(int jump, const char *fmt, ...)
 
 /* used by error reporting functions to print "ksh: .kshrc[25]: " */
 void
-error_prefix(int fileline)
+error_prefix(fileline)
+	int fileline;
 {
 	/* Avoid foo: foo[2]: ... */
 	if (!fileline || !source || !source->file
@@ -121,7 +148,13 @@ error_prefix(int fileline)
 
 /* printf to shl_out (stderr) with flush */
 void
+#ifdef HAVE_PROTOTYPES
 shellf(const char *fmt, ...)
+#else
+shellf(fmt, va_alist)
+	const char *fmt;
+	va_dcl
+#endif
 {
 	va_list va;
 
@@ -135,7 +168,13 @@ shellf(const char *fmt, ...)
 
 /* printf to shl_stdout (stdout) */
 void
+#ifdef HAVE_PROTOTYPES
 shprintf(const char *fmt, ...)
+#else
+shprintf(fmt, va_alist)
+	const char *fmt;
+	va_dcl
+#endif
 {
 	va_list va;
 
@@ -150,7 +189,7 @@ shprintf(const char *fmt, ...)
 static struct shf *kshdebug_shf;
 
 void
-kshdebug_init_(void)
+kshdebug_init_()
 {
 	if (kshdebug_shf)
 		shf_close(kshdebug_shf);
@@ -165,7 +204,13 @@ kshdebug_init_(void)
 
 /* print to debugging log */
 void
+# ifdef HAVE_PROTOTYPES
 kshdebug_printf_(const char *fmt, ...)
+# else
+kshdebug_printf_(fmt, va_alist)
+	const char *fmt;
+	va_dcl
+# endif
 {
 	va_list va;
 
@@ -179,7 +224,10 @@ kshdebug_printf_(const char *fmt, ...)
 }
 
 void
-kshdebug_dump_(const char *str, const void *mem, int nbytes)
+kshdebug_dump_(str, mem, nbytes)
+	const char *str;
+	const void *mem;
+	int nbytes;
 {
 	int i, j;
 	int nprow = 16;
@@ -202,7 +250,8 @@ kshdebug_dump_(const char *str, const void *mem, int nbytes)
 
 /* test if we can seek backwards fd (returns 0 or SHF_UNBUF) */
 int
-can_seek(int fd)
+can_seek(fd)
+	int fd;
 {
 	struct stat statb;
 
@@ -213,7 +262,7 @@ can_seek(int fd)
 struct shf	shf_iob[3];
 
 void
-initio(void)
+initio()
 {
 	shf_fdopen(1, SHF_WR, shl_stdout);	/* force buffer allocation */
 	shf_fdopen(2, SHF_WR, shl_out);
@@ -224,7 +273,10 @@ initio(void)
 
 /* A dup2() with error checking */
 int
-ksh_dup2(int ofd, int nfd, int errok)
+ksh_dup2(ofd, nfd, errok)
+	int ofd;
+	int nfd;
+	int errok;
 {
 	int ret = dup2(ofd, nfd);
 
@@ -245,7 +297,9 @@ ksh_dup2(int ofd, int nfd, int errok)
  * set close-on-exec flag.
  */
 int
-savefd(int fd, int noclose)
+savefd(fd, noclose)
+	int fd;
+	int noclose;
 {
 	int nfd;
 
@@ -266,7 +320,8 @@ savefd(int fd, int noclose)
 }
 
 void
-restfd(int fd, int ofd)
+restfd(fd, ofd)
+	int fd, ofd;
 {
 	if (fd == 2)
 		shf_flush(&shf_iob[fd]);
@@ -279,7 +334,8 @@ restfd(int fd, int ofd)
 }
 
 void
-openpipe(register int *pv)
+openpipe(pv)
+	register int *pv;
 {
 	if (pipe(pv) < 0)
 		errorf("can't create pipe - try again");
@@ -288,7 +344,8 @@ openpipe(register int *pv)
 }
 
 void
-closepipe(register int *pv)
+closepipe(pv)
+	register int *pv;
 {
 	close(pv[0]);
 	close(pv[1]);
@@ -298,7 +355,10 @@ closepipe(register int *pv)
  * a string (the X in 2>&X, read -uX, print -uX) into a file descriptor.
  */
 int
-check_fd(char *name, int mode, const char **emsgp)
+check_fd(name, mode, emsgp)
+	char *name;
+	int mode;
+	const char **emsgp;
 {
 	int fd, fl;
 
@@ -353,7 +413,7 @@ check_fd(char *name, int mode, const char **emsgp)
 #ifdef KSH
 /* Called once from main */
 void
-coproc_init(void)
+coproc_init()
 {
 	coproc.read = coproc.readw = coproc.write = -1;
 	coproc.njobs = 0;
@@ -362,7 +422,8 @@ coproc_init(void)
 
 /* Called by c_read() when eof is read - close fd if it is the co-process fd */
 void
-coproc_read_close(int fd)
+coproc_read_close(fd)
+	int fd;
 {
 	if (coproc.read >= 0 && fd == coproc.read) {
 		coproc_readw_close(fd);
@@ -375,7 +436,8 @@ coproc_read_close(int fd)
  * read pipe, so reads will actually terminate.
  */
 void
-coproc_readw_close(int fd)
+coproc_readw_close(fd)
+	int fd;
 {
 	if (coproc.readw >= 0 && coproc.read >= 0 && fd == coproc.read) {
 		close(coproc.readw);
@@ -387,7 +449,8 @@ coproc_readw_close(int fd)
  * when co-process input is dup'd
  */
 void
-coproc_write_close(int fd)
+coproc_write_close(fd)
+	int fd;
 {
 	if (coproc.write >= 0 && fd == coproc.write) {
 		close(coproc.write);
@@ -399,7 +462,9 @@ coproc_write_close(int fd)
  * (Used by check_fd() and by c_read/c_print to deal with -p option).
  */
 int
-coproc_getfd(int mode, const char **emsgp)
+coproc_getfd(mode, emsgp)
+	int mode;
+	const char **emsgp;
 {
 	int fd = (mode & R_OK) ? coproc.read : coproc.write;
 
@@ -414,7 +479,8 @@ coproc_getfd(int mode, const char **emsgp)
  * Should be called with SIGCHLD blocked.
  */
 void
-coproc_cleanup(int reuse)
+coproc_cleanup(reuse)
+	int reuse;
 {
 	/* This to allow co-processes to share output pipe */
 	if (!reuse || coproc.readw < 0 || coproc.read < 0) {
@@ -440,7 +506,10 @@ coproc_cleanup(int reuse)
  */
 
 struct temp *
-maketemp(Area *ap, Temp_type type, struct temp **tlist)
+maketemp(ap, type, tlist)
+	Area *ap;
+	Temp_type type;
+	struct temp **tlist;
 {
 #ifndef __NetBSD__
 	static unsigned int inc;
@@ -497,4 +566,3 @@ maketemp(Area *ap, Temp_type type, struct temp **tlist)
 
 	return tp;
 }
-

--- a/bin/ksh/io.c
+++ b/bin/ksh/io.c
@@ -23,13 +23,7 @@ static int initio_done;
 
 /* A shell error occurred (eg, syntax error, etc.) */
 void
-#ifdef HAVE_PROTOTYPES
 errorf(const char *fmt, ...)
-#else
-errorf(fmt, va_alist)
-	const char *fmt;
-	va_dcl
-#endif
 {
 	va_list va;
 
@@ -48,14 +42,7 @@ errorf(fmt, va_alist)
 
 /* like errorf(), but no unwind is done */
 void
-#ifdef HAVE_PROTOTYPES
 warningf(int fileline, const char *fmt, ...)
-#else
-warningf(fileline, fmt, va_alist)
-	int fileline;
-	const char *fmt;
-	va_dcl
-#endif
 {
 	va_list va;
 
@@ -71,13 +58,7 @@ warningf(fileline, fmt, va_alist)
  * (also unwinds environments for special builtins).
  */
 void
-#ifdef HAVE_PROTOTYPES
 bi_errorf(const char *fmt, ...)
-#else
-bi_errorf(fmt, va_alist)
-	const char *fmt;
-	va_dcl
-#endif
 {
 	va_list va;
 
@@ -108,14 +89,7 @@ bi_errorf(fmt, va_alist)
 
 /* Called when something that shouldn't happen does */
 void
-#ifdef HAVE_PROTOTYPES
 internal_errorf(int jump, const char *fmt, ...)
-#else
-internal_errorf(jump, fmt, va_alist)
-	int jump;
-	const char *fmt;
-	va_dcl
-#endif
 {
 	va_list va;
 
@@ -132,8 +106,7 @@ internal_errorf(jump, fmt, va_alist)
 
 /* used by error reporting functions to print "ksh: .kshrc[25]: " */
 void
-error_prefix(fileline)
-	int fileline;
+error_prefix(int fileline)
 {
 	/* Avoid foo: foo[2]: ... */
 	if (!fileline || !source || !source->file
@@ -148,13 +121,7 @@ error_prefix(fileline)
 
 /* printf to shl_out (stderr) with flush */
 void
-#ifdef HAVE_PROTOTYPES
 shellf(const char *fmt, ...)
-#else
-shellf(fmt, va_alist)
-	const char *fmt;
-	va_dcl
-#endif
 {
 	va_list va;
 
@@ -168,13 +135,7 @@ shellf(fmt, va_alist)
 
 /* printf to shl_stdout (stdout) */
 void
-#ifdef HAVE_PROTOTYPES
 shprintf(const char *fmt, ...)
-#else
-shprintf(fmt, va_alist)
-	const char *fmt;
-	va_dcl
-#endif
 {
 	va_list va;
 
@@ -189,7 +150,7 @@ shprintf(fmt, va_alist)
 static struct shf *kshdebug_shf;
 
 void
-kshdebug_init_()
+kshdebug_init_(void)
 {
 	if (kshdebug_shf)
 		shf_close(kshdebug_shf);
@@ -204,13 +165,7 @@ kshdebug_init_()
 
 /* print to debugging log */
 void
-# ifdef HAVE_PROTOTYPES
 kshdebug_printf_(const char *fmt, ...)
-# else
-kshdebug_printf_(fmt, va_alist)
-	const char *fmt;
-	va_dcl
-# endif
 {
 	va_list va;
 
@@ -224,10 +179,7 @@ kshdebug_printf_(fmt, va_alist)
 }
 
 void
-kshdebug_dump_(str, mem, nbytes)
-	const char *str;
-	const void *mem;
-	int nbytes;
+kshdebug_dump_(const char *str, const void *mem, int nbytes)
 {
 	int i, j;
 	int nprow = 16;
@@ -250,8 +202,7 @@ kshdebug_dump_(str, mem, nbytes)
 
 /* test if we can seek backwards fd (returns 0 or SHF_UNBUF) */
 int
-can_seek(fd)
-	int fd;
+can_seek(int fd)
 {
 	struct stat statb;
 
@@ -262,7 +213,7 @@ can_seek(fd)
 struct shf	shf_iob[3];
 
 void
-initio()
+initio(void)
 {
 	shf_fdopen(1, SHF_WR, shl_stdout);	/* force buffer allocation */
 	shf_fdopen(2, SHF_WR, shl_out);
@@ -273,10 +224,7 @@ initio()
 
 /* A dup2() with error checking */
 int
-ksh_dup2(ofd, nfd, errok)
-	int ofd;
-	int nfd;
-	int errok;
+ksh_dup2(int ofd, int nfd, int errok)
 {
 	int ret = dup2(ofd, nfd);
 
@@ -297,9 +245,7 @@ ksh_dup2(ofd, nfd, errok)
  * set close-on-exec flag.
  */
 int
-savefd(fd, noclose)
-	int fd;
-	int noclose;
+savefd(int fd, int noclose)
 {
 	int nfd;
 
@@ -320,8 +266,7 @@ savefd(fd, noclose)
 }
 
 void
-restfd(fd, ofd)
-	int fd, ofd;
+restfd(int fd, int ofd)
 {
 	if (fd == 2)
 		shf_flush(&shf_iob[fd]);
@@ -334,8 +279,7 @@ restfd(fd, ofd)
 }
 
 void
-openpipe(pv)
-	register int *pv;
+openpipe(register int *pv)
 {
 	if (pipe(pv) < 0)
 		errorf("can't create pipe - try again");
@@ -344,8 +288,7 @@ openpipe(pv)
 }
 
 void
-closepipe(pv)
-	register int *pv;
+closepipe(register int *pv)
 {
 	close(pv[0]);
 	close(pv[1]);
@@ -355,10 +298,7 @@ closepipe(pv)
  * a string (the X in 2>&X, read -uX, print -uX) into a file descriptor.
  */
 int
-check_fd(name, mode, emsgp)
-	char *name;
-	int mode;
-	const char **emsgp;
+check_fd(char *name, int mode, const char **emsgp)
 {
 	int fd, fl;
 
@@ -413,7 +353,7 @@ check_fd(name, mode, emsgp)
 #ifdef KSH
 /* Called once from main */
 void
-coproc_init()
+coproc_init(void)
 {
 	coproc.read = coproc.readw = coproc.write = -1;
 	coproc.njobs = 0;
@@ -422,8 +362,7 @@ coproc_init()
 
 /* Called by c_read() when eof is read - close fd if it is the co-process fd */
 void
-coproc_read_close(fd)
-	int fd;
+coproc_read_close(int fd)
 {
 	if (coproc.read >= 0 && fd == coproc.read) {
 		coproc_readw_close(fd);
@@ -436,8 +375,7 @@ coproc_read_close(fd)
  * read pipe, so reads will actually terminate.
  */
 void
-coproc_readw_close(fd)
-	int fd;
+coproc_readw_close(int fd)
 {
 	if (coproc.readw >= 0 && coproc.read >= 0 && fd == coproc.read) {
 		close(coproc.readw);
@@ -449,8 +387,7 @@ coproc_readw_close(fd)
  * when co-process input is dup'd
  */
 void
-coproc_write_close(fd)
-	int fd;
+coproc_write_close(int fd)
 {
 	if (coproc.write >= 0 && fd == coproc.write) {
 		close(coproc.write);
@@ -462,9 +399,7 @@ coproc_write_close(fd)
  * (Used by check_fd() and by c_read/c_print to deal with -p option).
  */
 int
-coproc_getfd(mode, emsgp)
-	int mode;
-	const char **emsgp;
+coproc_getfd(int mode, const char **emsgp)
 {
 	int fd = (mode & R_OK) ? coproc.read : coproc.write;
 
@@ -479,8 +414,7 @@ coproc_getfd(mode, emsgp)
  * Should be called with SIGCHLD blocked.
  */
 void
-coproc_cleanup(reuse)
-	int reuse;
+coproc_cleanup(int reuse)
 {
 	/* This to allow co-processes to share output pipe */
 	if (!reuse || coproc.readw < 0 || coproc.read < 0) {
@@ -506,10 +440,7 @@ coproc_cleanup(reuse)
  */
 
 struct temp *
-maketemp(ap, type, tlist)
-	Area *ap;
-	Temp_type type;
-	struct temp **tlist;
+maketemp(Area *ap, Temp_type type, struct temp **tlist)
 {
 #ifndef __NetBSD__
 	static unsigned int inc;
@@ -566,3 +497,4 @@ maketemp(ap, type, tlist)
 
 	return tp;
 }
+

--- a/bin/ksh/jobs.c
+++ b/bin/ksh/jobs.c
@@ -66,13 +66,16 @@ int tcsetpgrp ARGS((int fd, pid_t grp));
 int tcgetpgrp ARGS((int fd));
 
 int
-tcsetpgrp(int fd, pid_t grp)
+tcsetpgrp(fd, grp)
+	int fd;
+	pid_t grp;
 {
 	return ioctl(fd, TIOCSPGRP, &grp);
 }
 
 int
-tcgetpgrp(int fd)
+tcgetpgrp(fd)
+	int	fd;
 {
 	int r, grp;
 
@@ -228,7 +231,8 @@ static int		kill_job ARGS((Job *j, int sig));
 
 /* initialize job control */
 void
-j_init(int mflagset)
+j_init(mflagset)
+	int mflagset;
 {
 	child_max = CHILD_MAX; /* so syscon() isn't always being called */
 
@@ -282,7 +286,7 @@ j_init(int mflagset)
 
 /* job cleanup before shell exit */
 void
-j_exit(void)
+j_exit()
 {
 	/* kill stopped, and possibly running, jobs */
 	Job	*j;
@@ -339,7 +343,7 @@ j_exit(void)
 #ifdef JOBS
 /* turn job control on or off according to Flag(FMONITOR) */
 void
-j_change(void)
+j_change()
 {
 	int i;
 
@@ -432,11 +436,12 @@ j_change(void)
 }
 #endif /* JOBS */
 
-/* execute tree in child subprocess
- * close_fd used if XPCLOSE or XCCLOSE
-*/
+/* execute tree in child subprocess */
 int
-exchild(struct op *t, int flags, int close_fd)
+exchild(t, flags, close_fd)
+	struct op	*t;
+	int		flags;
+	int		close_fd;	/* used if XPCLOSE or XCCLOSE */
 {
 	static Proc	*last_proc;	/* for pipelines */
 
@@ -695,7 +700,7 @@ exchild(struct op *t, int flags, int close_fd)
 
 /* start the last job: only used for `command` jobs */
 void
-startlast(void)
+startlast()
 {
 #ifdef JOB_SIGS
 	sigset_t omask;
@@ -715,7 +720,7 @@ startlast(void)
 
 /* wait for last job: only used for `command` jobs */
 int
-waitlast(void)
+waitlast()
 {
 	int	rv;
 	Job	*j;
@@ -748,7 +753,9 @@ waitlast(void)
 
 /* wait for child, interruptable. */
 int
-waitfor(const char *cp, int *sigp)
+waitfor(cp, sigp)
+	const char *cp;
+	int	*sigp;
 {
 	int	rv;
 	Job	*j;
@@ -809,7 +816,9 @@ waitfor(const char *cp, int *sigp)
 
 /* kill (built-in) a job */
 int
-j_kill(const char *cp, int sig)
+j_kill(cp, sig)
+	const char *cp;
+	int	sig;
 {
 	Job	*j;
 	int	rv = 0;
@@ -854,7 +863,9 @@ j_kill(const char *cp, int sig)
 #ifdef JOBS
 /* fg and bg built-ins: called only if Flag(FMONITOR) set */
 int
-j_resume(const char *cp, int bg)
+j_resume(cp, bg)
+	const char *cp;
+	int	bg;
 {
 	Job	*j;
 	Proc	*p;
@@ -960,7 +971,7 @@ j_resume(const char *cp, int bg)
 
 /* are there any running or stopped jobs ? */
 int
-j_stopped_running(void)
+j_stopped_running()
 {
 	Job	*j;
 	int	which = 0;
@@ -985,11 +996,12 @@ j_stopped_running(void)
 	return 0;
 }
 
-/* list jobs for jobs built-in
- * slp: 0 for short, 1 for long, 3 for pgrp
- */
+/* list jobs for jobs built-in */
 int
-j_jobs(const char *cp, int slp, int nflag)
+j_jobs(cp, slp, nflag)
+	const char *cp;
+	int	slp;		/* 0: short, 1: long, 2: pgrp */
+	int	nflag;
 {
 	Job	*j, *tmp;
 	int	how;
@@ -1042,7 +1054,7 @@ j_jobs(const char *cp, int slp, int nflag)
 
 /* list jobs for top-level notification */
 void
-j_notify(void)
+j_notify()
 {
 	Job	*j, *tmp;
 #ifdef JOB_SIGS
@@ -1074,7 +1086,7 @@ j_notify(void)
 
 /* Return pid of last process in last asynchronous job */
 pid_t
-j_async(void)
+j_async()
 {
 #ifdef JOB_SIGS
 	sigset_t omask;
@@ -1097,7 +1109,8 @@ j_async(void)
  * If jobs are compiled in then this routine expects sigchld to be blocked.
  */
 static void
-j_set_async(Job *j)
+j_set_async(j)
+	Job *j;
 {
 	Job	*jl, *oldest;
 
@@ -1132,7 +1145,8 @@ j_set_async(Job *j)
  * If jobs are compiled in then this routine expects sigchld to be blocked.
  */
 static void
-j_startjob(Job *j)
+j_startjob(j)
+	Job *j;
 {
 	Proc	*p;
 
@@ -1160,11 +1174,12 @@ j_startjob(Job *j)
  * wait for job to complete or change state
  *
  * If jobs are compiled in then this routine expects sigchld to be blocked.
- *
- * see JW_* for flags parameter
  */
 static int
-j_waitj(Job *j, int flags, const char *where)
+j_waitj(j, flags, where)
+	Job	*j;
+	int	flags;		/* see JW_* */
+	const char *where;
 {
 	int	rv;
 
@@ -1299,7 +1314,8 @@ j_waitj(Job *j, int flags, const char *where)
  * If jobs are compiled in then this routine expects sigchld to be blocked.
  */
 static RETSIGTYPE
-j_sigchld(int sig)
+j_sigchld(sig)
+	int	sig;
 {
 	int		errno_ = errno;
 	Job		*j;
@@ -1385,7 +1401,8 @@ found:
  * If jobs are compiled in then this routine expects sigchld to be blocked.
  */
 static void
-check_job(Job *j)
+check_job(j)
+	Job	*j;
 {
 	int	jstate;
 	Proc	*p;
@@ -1493,7 +1510,10 @@ check_job(Job *j)
  * If jobs are compiled in then this routine expects sigchld to be blocked.
  */
 static void
-j_print(Job *j, int how, struct shf *shf)
+j_print(j, how, shf)
+	Job		*j;
+	int		how;
+	struct shf	*shf;
 {
 	Proc	*p;
 	int	state;
@@ -1602,7 +1622,9 @@ j_print(Job *j, int how, struct shf *shf)
  * If jobs are compiled in then this routine expects sigchld to be blocked.
  */
 static Job *
-j_lookup(const char *cp, int *ecodep)
+j_lookup(cp, ecodep)
+	const char *cp;
+	int	*ecodep;
 {
 	Job		*j, *last_match;
 	Proc		*p;
@@ -1695,7 +1717,7 @@ static Proc	*free_procs;
  * If jobs are compiled in then this routine expects sigchld to be blocked.
  */
 static Job *
-new_job(void)
+new_job()
 {
 	int	i;
 	Job	*newj, *j;
@@ -1723,7 +1745,7 @@ new_job(void)
  * If jobs are compiled in then this routine expects sigchld to be blocked.
  */
 static Proc *
-new_proc(void)
+new_proc()
 {
 	Proc	*p;
 
@@ -1742,7 +1764,9 @@ new_proc(void)
  * If jobs are compiled in then this routine expects sigchld to be blocked.
  */
 static void
-remove_job(Job *j, const char *where)
+remove_job(j, where)
+	Job	*j;
+	const char *where;
 {
 	Proc	*p, *tmp;
 	Job	**prev, *curr;
@@ -1782,7 +1806,9 @@ remove_job(Job *j, const char *where)
  * If jobs are compiled in then this routine expects sigchld to be blocked.
  */
 static void
-put_job(Job *j, int where)
+put_job(j, where)
+	Job	*j;
+	int	where;
 {
 	Job	**prev, *curr;
 
@@ -1817,7 +1843,9 @@ put_job(Job *j, int where)
  * If jobs are compiled in then this routine expects sigchld to be blocked.
  */
 static int
-kill_job(Job *j, int sig)
+kill_job(j, sig)
+	Job	*j;
+	int	sig;
 {
 	Proc	*p;
 	int	rval = 0;
@@ -1828,4 +1856,3 @@ kill_job(Job *j, int sig)
 				rval = -1;
 	return rval;
 }
-

--- a/bin/ksh/ksh_dir.h
+++ b/bin/ksh/ksh_dir.h
@@ -25,4 +25,3 @@ extern DIR *ksh_opendir ARGS((const char *d));
 #else /* OPENDIR_DOES_NONDIR */
 # define ksh_opendir(d)	opendir(d)
 #endif /* OPENDIR_DOES_NONDIR */
-

--- a/bin/ksh/ksh_dir.h
+++ b/bin/ksh/ksh_dir.h
@@ -25,3 +25,4 @@ extern DIR *ksh_opendir ARGS((const char *d));
 #else /* OPENDIR_DOES_NONDIR */
 # define ksh_opendir(d)	opendir(d)
 #endif /* OPENDIR_DOES_NONDIR */
+

--- a/bin/ksh/ksh_limval.h
+++ b/bin/ksh/ksh_limval.h
@@ -23,4 +23,3 @@
 #ifndef BITS
 # define BITS(t)	(BITSPERBYTE * sizeof(t))
 #endif
-

--- a/bin/ksh/ksh_limval.h
+++ b/bin/ksh/ksh_limval.h
@@ -23,3 +23,4 @@
 #ifndef BITS
 # define BITS(t)	(BITSPERBYTE * sizeof(t))
 #endif
+

--- a/bin/ksh/ksh_stat.h
+++ b/bin/ksh/ksh_stat.h
@@ -58,3 +58,4 @@
 #ifndef S_IXOTH
 # define S_IXOTH	00001	/* user execute bit */
 #endif /* S_IXOTH */
+

--- a/bin/ksh/ksh_stat.h
+++ b/bin/ksh/ksh_stat.h
@@ -58,4 +58,3 @@
 #ifndef S_IXOTH
 # define S_IXOTH	00001	/* user execute bit */
 #endif /* S_IXOTH */
-

--- a/bin/ksh/ksh_time.h
+++ b/bin/ksh/ksh_time.h
@@ -25,3 +25,4 @@ extern time_t time ARGS((time_t *));
 # define CLK_TCK 60			/* 60HZ */
 #endif
 #endif /* KSH_TIME_H */
+

--- a/bin/ksh/ksh_time.h
+++ b/bin/ksh/ksh_time.h
@@ -25,4 +25,3 @@ extern time_t time ARGS((time_t *));
 # define CLK_TCK 60			/* 60HZ */
 #endif
 #endif /* KSH_TIME_H */
-

--- a/bin/ksh/ksh_times.h
+++ b/bin/ksh/ksh_times.h
@@ -18,4 +18,3 @@ extern clock_t	ksh_times ARGS((struct tms *));
 extern clock_t	times ARGS((struct tms *));
 #endif /* HAVE_TIMES */
 #endif /* KSH_TIMES_H */
-

--- a/bin/ksh/ksh_times.h
+++ b/bin/ksh/ksh_times.h
@@ -18,3 +18,4 @@ extern clock_t	ksh_times ARGS((struct tms *));
 extern clock_t	times ARGS((struct tms *));
 #endif /* HAVE_TIMES */
 #endif /* KSH_TIMES_H */
+

--- a/bin/ksh/ksh_wait.h
+++ b/bin/ksh/ksh_wait.h
@@ -50,3 +50,4 @@ typedef int WAIT_T;
 #else /* !HAVE_WAITPID && HAVE_WAIT3 */
 # define ksh_waitpid(p, s, o)	waitpid((p), (s), (o))
 #endif /* !HAVE_WAITPID && HAVE_WAIT3 */
+

--- a/bin/ksh/ksh_wait.h
+++ b/bin/ksh/ksh_wait.h
@@ -50,4 +50,3 @@ typedef int WAIT_T;
 #else /* !HAVE_WAITPID && HAVE_WAIT3 */
 # define ksh_waitpid(p, s, o)	waitpid((p), (s), (o))
 #endif /* !HAVE_WAITPID && HAVE_WAIT3 */
-

--- a/bin/ksh/lex.c
+++ b/bin/ksh/lex.c
@@ -103,8 +103,7 @@ static int ignore_backslash_newline;
  */
 
 int
-yylex(cf)
-	int cf;
+yylex(int cf)
 {
 	Lex_state states[STATE_BSIZE], *statep;
 	State_info state_info;
@@ -769,7 +768,7 @@ Done:
 }
 
 static void
-gethere()
+gethere(void)
 {
 	register struct ioword **p;
 
@@ -783,8 +782,7 @@ gethere()
  */
 
 static void
-readhere(iop)
-	struct ioword *iop;
+readhere(struct ioword *iop)
 {
 	register int c;
 	char *volatile eof;
@@ -842,13 +840,7 @@ readhere(iop)
 }
 
 void
-#ifdef HAVE_PROTOTYPES
 yyerror(const char *fmt, ...)
-#else
-yyerror(fmt, va_alist)
-	const char *fmt;
-	va_dcl
-#endif
 {
 	va_list va;
 
@@ -869,9 +861,7 @@ yyerror(fmt, va_alist)
  */
 
 Source *
-pushs(type, areap)
-	int type;
-	Area *areap;
+pushs(int type, Area *areap)
 {
 	register Source *s;
 
@@ -894,7 +884,7 @@ pushs(type, areap)
 }
 
 static int
-getsc__()
+getsc__(void)
 {
 	register Source *s = source;
 	register int c;
@@ -995,8 +985,7 @@ getsc__()
 }
 
 static void
-getsc_line(s)
-	Source *s;
+getsc_line(Source *s)
 {
 	char *xp = Xstring(s->xs, xp);
 	int interactive = Flag(FTALKING) && s->type == SSTDIN;
@@ -1108,9 +1097,7 @@ getsc_line(s)
 }
 
 void
-set_prompt(to, s)
-	int to;
-	Source *s;
+set_prompt(int to, Source *s)
 {
 	cur_prompt = to;
 
@@ -1166,9 +1153,7 @@ set_prompt(to, s)
 
 /* See also related routine, promptlen() in edit.c */
 void
-pprompt(cp, ntruncate)
-	const char *cp;
-	int ntruncate;
+pprompt(const char *cp, int ntruncate)
 {
 #if 0
 	char nbuf[32];
@@ -1212,9 +1197,7 @@ pprompt(cp, ntruncate)
  * the :[-+?=#%] or close-brace.
  */
 static char *
-get_brace_var(wsp, wp)
-	XString *wsp;
-	char *wp;
+get_brace_var(XString *wsp, char *wp)
 {
 	enum parse_state {
 			   PS_INITIAL, PS_SAW_HASH, PS_IDENT,
@@ -1289,8 +1272,7 @@ get_brace_var(wsp, wp)
  * (Returned string double null terminated)
  */
 static int
-arraysub(strp)
-	char **strp;
+arraysub(char **strp)
 {
 	XString ws;
 	char	*wp;
@@ -1317,8 +1299,7 @@ arraysub(strp)
 
 /* Unget a char: handles case when we are already at the start of the buffer */
 static const char *
-ungetsc(c)
-	int c;
+ungetsc(int c)
 {
 	if (backslash_skip)
 		backslash_skip--;
@@ -1370,9 +1351,7 @@ getsc_bn ARGS((void))
 }
 
 static Lex_state *
-push_state_(si, old_end)
-	State_info *si;
-	Lex_state *old_end;
+push_state_(State_info *si, Lex_state *old_end)
 {
 	Lex_state	*new = alloc(sizeof(Lex_state) * STATE_BSIZE, ATEMP);
 
@@ -1383,9 +1362,7 @@ push_state_(si, old_end)
 }
 
 static Lex_state *
-pop_state_(si, old_end)
-	State_info *si;
-	Lex_state *old_end;
+pop_state_(State_info *si, Lex_state *old_end)
 {
 	Lex_state *old_base = si->base;
 
@@ -1396,3 +1373,4 @@ pop_state_(si, old_end)
 
 	return si->base + STATE_BSIZE - 1;
 }
+

--- a/bin/ksh/lex.c
+++ b/bin/ksh/lex.c
@@ -103,7 +103,8 @@ static int ignore_backslash_newline;
  */
 
 int
-yylex(int cf)
+yylex(cf)
+	int cf;
 {
 	Lex_state states[STATE_BSIZE], *statep;
 	State_info state_info;
@@ -768,7 +769,7 @@ Done:
 }
 
 static void
-gethere(void)
+gethere()
 {
 	register struct ioword **p;
 
@@ -782,7 +783,8 @@ gethere(void)
  */
 
 static void
-readhere(struct ioword *iop)
+readhere(iop)
+	struct ioword *iop;
 {
 	register int c;
 	char *volatile eof;
@@ -840,7 +842,13 @@ readhere(struct ioword *iop)
 }
 
 void
+#ifdef HAVE_PROTOTYPES
 yyerror(const char *fmt, ...)
+#else
+yyerror(fmt, va_alist)
+	const char *fmt;
+	va_dcl
+#endif
 {
 	va_list va;
 
@@ -861,7 +869,9 @@ yyerror(const char *fmt, ...)
  */
 
 Source *
-pushs(int type, Area *areap)
+pushs(type, areap)
+	int type;
+	Area *areap;
 {
 	register Source *s;
 
@@ -884,7 +894,7 @@ pushs(int type, Area *areap)
 }
 
 static int
-getsc__(void)
+getsc__()
 {
 	register Source *s = source;
 	register int c;
@@ -985,7 +995,8 @@ getsc__(void)
 }
 
 static void
-getsc_line(Source *s)
+getsc_line(s)
+	Source *s;
 {
 	char *xp = Xstring(s->xs, xp);
 	int interactive = Flag(FTALKING) && s->type == SSTDIN;
@@ -1097,7 +1108,9 @@ getsc_line(Source *s)
 }
 
 void
-set_prompt(int to, Source *s)
+set_prompt(to, s)
+	int to;
+	Source *s;
 {
 	cur_prompt = to;
 
@@ -1153,7 +1166,9 @@ set_prompt(int to, Source *s)
 
 /* See also related routine, promptlen() in edit.c */
 void
-pprompt(const char *cp, int ntruncate)
+pprompt(cp, ntruncate)
+	const char *cp;
+	int ntruncate;
 {
 #if 0
 	char nbuf[32];
@@ -1197,7 +1212,9 @@ pprompt(const char *cp, int ntruncate)
  * the :[-+?=#%] or close-brace.
  */
 static char *
-get_brace_var(XString *wsp, char *wp)
+get_brace_var(wsp, wp)
+	XString *wsp;
+	char *wp;
 {
 	enum parse_state {
 			   PS_INITIAL, PS_SAW_HASH, PS_IDENT,
@@ -1272,7 +1289,8 @@ get_brace_var(XString *wsp, char *wp)
  * (Returned string double null terminated)
  */
 static int
-arraysub(char **strp)
+arraysub(strp)
+	char **strp;
 {
 	XString ws;
 	char	*wp;
@@ -1299,7 +1317,8 @@ arraysub(char **strp)
 
 /* Unget a char: handles case when we are already at the start of the buffer */
 static const char *
-ungetsc(int c)
+ungetsc(c)
+	int c;
 {
 	if (backslash_skip)
 		backslash_skip--;
@@ -1351,7 +1370,9 @@ getsc_bn ARGS((void))
 }
 
 static Lex_state *
-push_state_(State_info *si, Lex_state *old_end)
+push_state_(si, old_end)
+	State_info *si;
+	Lex_state *old_end;
 {
 	Lex_state	*new = alloc(sizeof(Lex_state) * STATE_BSIZE, ATEMP);
 
@@ -1362,7 +1383,9 @@ push_state_(State_info *si, Lex_state *old_end)
 }
 
 static Lex_state *
-pop_state_(State_info *si, Lex_state *old_end)
+pop_state_(si, old_end)
+	State_info *si;
+	Lex_state *old_end;
 {
 	Lex_state *old_base = si->base;
 
@@ -1373,4 +1396,3 @@ pop_state_(State_info *si, Lex_state *old_end)
 
 	return si->base + STATE_BSIZE - 1;
 }
-

--- a/bin/ksh/lex.h
+++ b/bin/ksh/lex.h
@@ -131,3 +131,4 @@ EXTERN	char  **histlist;	/* saved commands */
 EXTERN	char  **histptr;	/* last history item */
 EXTERN	int	histsize;	/* history size */
 #endif /* HISTORY */
+

--- a/bin/ksh/lex.h
+++ b/bin/ksh/lex.h
@@ -131,4 +131,3 @@ EXTERN	char  **histlist;	/* saved commands */
 EXTERN	char  **histptr;	/* last history item */
 EXTERN	int	histsize;	/* history size */
 #endif /* HISTORY */
-

--- a/bin/ksh/mail.c
+++ b/bin/ksh/mail.c
@@ -43,7 +43,7 @@ static mbox_t * mballoc     ARGS((char *p, char *m)); /* allocate a new mbox */
 static void     mprintit    ARGS((mbox_t *mbp));
 
 void
-mcheck(void)
+mcheck()
 {
 	register mbox_t	*mbp;
 	time_t		 now;
@@ -87,13 +87,15 @@ mcheck(void)
 }
 
 void
-mcset(long interval)
+mcset(interval)
+	long interval;
 {
 	mailcheck_interval = interval;
 }
 
 void
-mbset(register char *p)
+mbset(p)
+	register char	*p;
 {
 	struct stat	stbuf;
 
@@ -111,7 +113,8 @@ mbset(register char *p)
 }
 
 void
-mpset(register char *mptoparse)
+mpset(mptoparse)
+	register char	*mptoparse;
 {
 	register mbox_t	*mbp;
 	register char	*mpath, *mmsg, *mval;
@@ -150,7 +153,8 @@ mpset(register char *mptoparse)
 }
 
 static void
-munset(register mbox_t *mlist)
+munset(mlist)
+register mbox_t	*mlist;
 {
 	register mbox_t	*mbp;
 
@@ -164,7 +168,9 @@ munset(register mbox_t *mlist)
 }
 
 static mbox_t *
-mballoc(char *p, char *m)
+mballoc(p, m)
+	char	*p;
+	char	*m;
 {
 	struct stat	stbuf;
 	register mbox_t	*mbp;
@@ -181,7 +187,8 @@ mballoc(char *p, char *m)
 }
 
 static void
-mprintit(mbox_t *mbp)
+mprintit( mbp )
+mbox_t	*mbp;
 {
 	struct tbl	*vp;
 
@@ -193,4 +200,3 @@ mprintit(mbox_t *mbp)
 	unset(vp, 0);
 }
 #endif /* KSH */
-

--- a/bin/ksh/mail.c
+++ b/bin/ksh/mail.c
@@ -43,7 +43,7 @@ static mbox_t * mballoc     ARGS((char *p, char *m)); /* allocate a new mbox */
 static void     mprintit    ARGS((mbox_t *mbp));
 
 void
-mcheck()
+mcheck(void)
 {
 	register mbox_t	*mbp;
 	time_t		 now;
@@ -87,15 +87,13 @@ mcheck()
 }
 
 void
-mcset(interval)
-	long interval;
+mcset(long interval)
 {
 	mailcheck_interval = interval;
 }
 
 void
-mbset(p)
-	register char	*p;
+mbset(register char *p)
 {
 	struct stat	stbuf;
 
@@ -113,8 +111,7 @@ mbset(p)
 }
 
 void
-mpset(mptoparse)
-	register char	*mptoparse;
+mpset(register char *mptoparse)
 {
 	register mbox_t	*mbp;
 	register char	*mpath, *mmsg, *mval;
@@ -153,8 +150,7 @@ mpset(mptoparse)
 }
 
 static void
-munset(mlist)
-register mbox_t	*mlist;
+munset(register mbox_t *mlist)
 {
 	register mbox_t	*mbp;
 
@@ -168,9 +164,7 @@ register mbox_t	*mlist;
 }
 
 static mbox_t *
-mballoc(p, m)
-	char	*p;
-	char	*m;
+mballoc(char *p, char *m)
 {
 	struct stat	stbuf;
 	register mbox_t	*mbp;
@@ -187,8 +181,7 @@ mballoc(p, m)
 }
 
 static void
-mprintit( mbp )
-mbox_t	*mbp;
+mprintit(mbox_t *mbp)
 {
 	struct tbl	*vp;
 
@@ -200,3 +193,4 @@ mbox_t	*mbp;
 	unset(vp, 0);
 }
 #endif /* KSH */
+

--- a/bin/ksh/main.c
+++ b/bin/ksh/main.c
@@ -454,11 +454,7 @@ main(int argc, char *argv[])
 }
 
 int
-include(name, argc, argv, intr_ok)
-	const char *name;
-	int argc;
-	char **argv;
-	int intr_ok;
+include(const char *name, int argc, char **argv, int intr_ok)
 {
 	register Source *volatile s = NULL;
 	struct shf *shf;
@@ -526,8 +522,7 @@ include(name, argc, argv, intr_ok)
 }
 
 int
-command(comm)
-	const char *comm;
+command(const char *comm)
 {
 	register Source *s;
 	int r;
@@ -541,11 +536,10 @@ command(comm)
 
 /*
  * run the commands from the input source, returning status.
+ * s - input source
  */
 int
-shell(s, toplevel)
-	Source *volatile s;		/* input source */
-	int volatile toplevel;
+shell(Source *volatile s, int volatile toplevel)
 {
 	struct op *t;
 	volatile int wastty = s->flags & SF_TTY;
@@ -654,8 +648,7 @@ shell(s, toplevel)
 
 /* return to closest error handler or shell(), exit if none found */
 void
-unwind(i)
-	int i;
+unwind(int i)
 {
 	/* ordering for EXIT vs ERR is a bit odd (this is what at&t ksh does) */
 	if (i == LEXIT || (Flag(FERREXIT) && (i == LERROR || i == LINTR)
@@ -689,8 +682,7 @@ unwind(i)
 }
 
 void
-newenv(type)
-	int type;
+newenv(int type)
 {
 	register struct env *ep;
 
@@ -706,7 +698,7 @@ newenv(type)
 }
 
 void
-quitenv()
+quitenv(void)
 {
 	register struct env *ep = e;
 	register int fd;
@@ -758,7 +750,7 @@ quitenv()
 
 /* Called after a fork to cleanup stuff left over from parents environment */
 void
-cleanup_parents_env()
+cleanup_parents_env(void)
 {
 	struct env *ep;
 	int fd;
@@ -783,7 +775,7 @@ cleanup_parents_env()
 
 /* Called just before an execve cleanup stuff temporary files */
 void
-cleanup_proc_env()
+cleanup_proc_env(void)
 {
 	struct env *ep;
 
@@ -793,7 +785,7 @@ cleanup_proc_env()
 
 /* remove temp files and free ATEMP Area */
 static void
-reclaim()
+reclaim(void)
 {
 	remove_temps(e->temps);
 	e->temps = NULL;
@@ -801,8 +793,7 @@ reclaim()
 }
 
 static void
-remove_temps(tp)
-	struct temp *tp;
+remove_temps(struct temp *tp)
 {
 #ifdef OS2
 	static struct temp *delayed_remove;
@@ -847,8 +838,7 @@ remove_temps(tp)
 
 /* Returns true if name refers to a restricted shell */
 static int
-is_restricted(name)
-	char *name;
+is_restricted(char *name)
 {
 	char *p;
 
@@ -859,11 +849,10 @@ is_restricted(name)
 }
 
 void
-aerror(ap, msg)
-	Area *ap;
-	const char *msg;
+aerror(Area *ap, const char *msg)
 {
 	internal_errorf(1, "alloc: %s", msg);
 	errorf("%s", null); /* this is never executed - keeps gcc quiet */
 	/*NOTREACHED*/
 }
+

--- a/bin/ksh/main.c
+++ b/bin/ksh/main.c
@@ -454,7 +454,11 @@ main(int argc, char *argv[])
 }
 
 int
-include(const char *name, int argc, char **argv, int intr_ok)
+include(name, argc, argv, intr_ok)
+	const char *name;
+	int argc;
+	char **argv;
+	int intr_ok;
 {
 	register Source *volatile s = NULL;
 	struct shf *shf;
@@ -522,7 +526,8 @@ include(const char *name, int argc, char **argv, int intr_ok)
 }
 
 int
-command(const char *comm)
+command(comm)
+	const char *comm;
 {
 	register Source *s;
 	int r;
@@ -536,10 +541,11 @@ command(const char *comm)
 
 /*
  * run the commands from the input source, returning status.
- * s - input source
  */
 int
-shell(Source *volatile s, int volatile toplevel)
+shell(s, toplevel)
+	Source *volatile s;		/* input source */
+	int volatile toplevel;
 {
 	struct op *t;
 	volatile int wastty = s->flags & SF_TTY;
@@ -648,7 +654,8 @@ shell(Source *volatile s, int volatile toplevel)
 
 /* return to closest error handler or shell(), exit if none found */
 void
-unwind(int i)
+unwind(i)
+	int i;
 {
 	/* ordering for EXIT vs ERR is a bit odd (this is what at&t ksh does) */
 	if (i == LEXIT || (Flag(FERREXIT) && (i == LERROR || i == LINTR)
@@ -682,7 +689,8 @@ unwind(int i)
 }
 
 void
-newenv(int type)
+newenv(type)
+	int type;
 {
 	register struct env *ep;
 
@@ -698,7 +706,7 @@ newenv(int type)
 }
 
 void
-quitenv(void)
+quitenv()
 {
 	register struct env *ep = e;
 	register int fd;
@@ -750,7 +758,7 @@ quitenv(void)
 
 /* Called after a fork to cleanup stuff left over from parents environment */
 void
-cleanup_parents_env(void)
+cleanup_parents_env()
 {
 	struct env *ep;
 	int fd;
@@ -775,7 +783,7 @@ cleanup_parents_env(void)
 
 /* Called just before an execve cleanup stuff temporary files */
 void
-cleanup_proc_env(void)
+cleanup_proc_env()
 {
 	struct env *ep;
 
@@ -785,7 +793,7 @@ cleanup_proc_env(void)
 
 /* remove temp files and free ATEMP Area */
 static void
-reclaim(void)
+reclaim()
 {
 	remove_temps(e->temps);
 	e->temps = NULL;
@@ -793,7 +801,8 @@ reclaim(void)
 }
 
 static void
-remove_temps(struct temp *tp)
+remove_temps(tp)
+	struct temp *tp;
 {
 #ifdef OS2
 	static struct temp *delayed_remove;
@@ -838,7 +847,8 @@ remove_temps(struct temp *tp)
 
 /* Returns true if name refers to a restricted shell */
 static int
-is_restricted(char *name)
+is_restricted(name)
+	char *name;
 {
 	char *p;
 
@@ -849,10 +859,11 @@ is_restricted(char *name)
 }
 
 void
-aerror(Area *ap, const char *msg)
+aerror(ap, msg)
+	Area *ap;
+	const char *msg;
 {
 	internal_errorf(1, "alloc: %s", msg);
 	errorf("%s", null); /* this is never executed - keeps gcc quiet */
 	/*NOTREACHED*/
 }
-

--- a/bin/ksh/misc.c
+++ b/bin/ksh/misc.c
@@ -31,7 +31,9 @@ static const unsigned char *cclass ARGS((const unsigned char *p, int sub));
  * Fast character classes
  */
 void
-setctypes(register const char *s, register int t)
+setctypes(s, t)
+	register const char *s;
+	register int t;
 {
 	register int i;
 
@@ -45,7 +47,7 @@ setctypes(register const char *s, register int t)
 }
 
 void
-initctypes(void)
+initctypes()
 {
 	register int c;
 
@@ -66,7 +68,9 @@ initctypes(void)
 /* convert unsigned long to base N string */
 
 char *
-ulton(register unsigned long n, int base)
+ulton(n, base)
+	register unsigned long n;
+	int base;
 {
 	register char *p;
 	static char buf [20];
@@ -81,7 +85,9 @@ ulton(register unsigned long n, int base)
 }
 
 char *
-str_save(register const char *s, Area *ap)
+str_save(s, ap)
+	register const char *s;
+	Area *ap;
 {
 	size_t len;
 	char *p;
@@ -99,7 +105,10 @@ str_save(register const char *s, Area *ap)
  * (unless n < 0).
  */
 char *
-str_nsave(register const char *s, int n, Area *ap)
+str_nsave(s, n, ap)
+	register const char *s;
+	int n;
+	Area *ap;
 {
 	char *ns;
 
@@ -112,7 +121,10 @@ str_nsave(register const char *s, int n, Area *ap)
 
 /* called from expand.h:XcheckN() to grow buffer */
 char *
-Xcheck_grow_(XString *xsp, char *xp, int more)
+Xcheck_grow_(xsp, xp, more)
+	XString *xsp;
+	char *xp;
+	int more;
 {
 	char *old_beg = xsp->beg;
 
@@ -185,7 +197,8 @@ const struct option goptions[] = {
  * translate -o option into F* constant (also used for test -o option)
  */
 int
-option(const char *n)
+option(n)
+	const char *n;
 {
 	int i;
 
@@ -209,7 +222,11 @@ static void printoptions ARGS((int verbose));
 
 /* format a single select menu item */
 static char *
-options_fmt_entry(void *arg, int i, char *buf, int buflen)
+options_fmt_entry(arg, i, buf, buflen)
+	void *arg;
+	int i;
+	char *buf;
+	int buflen;
 {
 	struct options_info *oi = (struct options_info *) arg;
 
@@ -220,7 +237,8 @@ options_fmt_entry(void *arg, int i, char *buf, int buflen)
 }
 
 static void
-printoptions(int verbose)
+printoptions(verbose)
+	int verbose;
 {
 	int i;
 
@@ -252,7 +270,7 @@ printoptions(int verbose)
 }
 
 char *
-getoptions(void)
+getoptions()
 {
 	size_t i;
 	char m[(int) FNFLAGS + 1];
@@ -265,14 +283,12 @@ getoptions(void)
 	return str_save(m, ATEMP);
 }
 
-/* change a Flag(*) value; takes care of special actions
- *
- * f - flag to change
- * what - what is changing the flag (command line vs set)
- *
- */
+/* change a Flag(*) value; takes care of special actions */
 void
-change_flag(enum sh_flag f, int what, int newval)
+change_flag(f, what, newval)
+	enum sh_flag f;	/* flag to change */
+	int what;	/* what is changing the flag (command line vs set) */
+	int newval;
 {
 	int oldval;
 
@@ -330,11 +346,12 @@ change_flag(enum sh_flag f, int what, int newval)
 
 /* parse command line & set command arguments.  returns the index of
  * non-option arguments, -1 if there is an error.
- *
- * what - OF_CMDLINE or OF_SET
  */
 int
-parse_args(char **argv, int what, int *setargsp)
+parse_args(argv, what, setargsp)
+	char **argv;
+	int	what;		/* OF_CMDLINE or OF_SET */
+	int	*setargsp;
 {
 	static char cmd_opts[NELEM(goptions) + 3]; /* o:\0 */
 	static char set_opts[NELEM(goptions) + 5]; /* Ao;s\0 */
@@ -471,7 +488,9 @@ parse_args(char **argv, int what, int *setargsp)
 
 /* parse a decimal number: returns 0 if string isn't a number, 1 otherwise */
 int
-getn(const char *as, int *ai)
+getn(as, ai)
+	const char *as;
+	int *ai;
 {
 	char *p;
 	long n;
@@ -487,7 +506,9 @@ getn(const char *as, int *ai)
 
 /* getn() that prints error */
 int
-bi_getn(const char *as, int *ai)
+bi_getn(as, ai)
+	const char *as;
+	int *ai;
 {
 	int rv = getn(as, ai);
 
@@ -507,7 +528,9 @@ bi_getn(const char *as, int *ai)
  */
 
 int
-gmatch(const char *s, const char *p, int isfile)
+gmatch(s, p, isfile)
+	const char *s, *p;
+	int isfile;
 {
 	const char *se, *pe;
 
@@ -548,7 +571,8 @@ gmatch(const char *s, const char *p, int isfile)
 - return ?
 */
 int
-has_globbing(const char *xp, const char *xpe)
+has_globbing(xp, xpe)
+	const char *xp, *xpe;
 {
 	const unsigned char *p = (const unsigned char *) xp;
 	const unsigned char *pe = (const unsigned char *) xpe;
@@ -602,9 +626,10 @@ has_globbing(const char *xp, const char *xpe)
 
 /* Function must return either 0 or 1 (assumed by code for 0x80|'!') */
 static int
-do_gmatch(const unsigned char *s, const unsigned char *se,
-		  const unsigned char *p, const unsigned char *pe,
-		  int isfile)
+do_gmatch(s, se, p, pe, isfile)
+	const unsigned char *s, *p;
+	const unsigned char *se, *pe;
+	int isfile;
 {
 	register int sc, pc;
 	const unsigned char *prest, *psub, *pnext;
@@ -736,7 +761,9 @@ do_gmatch(const unsigned char *s, const unsigned char *se,
 }
 
 static const unsigned char *
-cclass(const unsigned char *p, register int sub)
+cclass(p, sub)
+	const unsigned char *p;
+	register int sub;
 {
 	register int c, d, not, found = 0;
 	const unsigned char *orig_p = p;
@@ -781,7 +808,10 @@ cclass(const unsigned char *p, register int sub)
 
 /* Look for next ) or | (if match_sep) in *(foo|bar) pattern */
 const unsigned char *
-pat_scan(const unsigned char *p, const unsigned char *pe, int match_sep)
+pat_scan(p, pe, match_sep)
+	const unsigned char *p;
+	const unsigned char *pe;
+	int match_sep;
 {
 	int nest = 0;
 
@@ -805,13 +835,11 @@ pat_scan(const unsigned char *p, const unsigned char *pe, int match_sep)
  */
 static void qsort1 ARGS((void **base, void **lim, int (*f)(void *, void *)));
 
-/*
- * base - base address
- * n - elements
- * f - compare function
- */
 void
-qsortp(void **base, size_t n, int (*f)(void*, void*))
+qsortp(base, n, f)
+	void **base;				/* base address */
+	size_t n;				/* elements */
+	int (*f) ARGS((void *, void *));	/* compare function */
 {
 	qsort1(base, base + n, f);
 }
@@ -824,7 +852,9 @@ qsortp(void **base, size_t n, int (*f)(void*, void*))
 }
 
 static void
-qsort1(void **base, void **lim, int (*f)(void *, void *))
+qsort1(base, lim, f)
+	void **base, **lim;
+	int (*f) ARGS((void *, void *));
 {
 	register void **i, **j;
 	register void **lptr, **hptr;
@@ -893,14 +923,17 @@ qsort1(void **base, void **lim, int (*f)(void *, void *))
 }
 
 int
-xstrcmp(void *p1, void *p2)
+xstrcmp(p1, p2)
+	void *p1, *p2;
 {
 	return (strcmp((char *)p1, (char *)p2));
 }
 
 /* Initialize a Getopt structure */
 void
-ksh_getopt_reset(Getopt *go, int flags)
+ksh_getopt_reset(go, flags)
+	Getopt *go;
+	int flags;
 {
 	go->optind = 1;
 	go->optarg = (char *) 0;
@@ -936,7 +969,10 @@ ksh_getopt_reset(Getopt *go, int flags)
  *	  in go->info.
  */
 int
-ksh_getopt(char **argv, Getopt *go, const char *options)
+ksh_getopt(argv, go, options)
+	char **argv;
+	Getopt *go;
+	const char *options;
 {
 	char c;
 	char *o;
@@ -1036,7 +1072,8 @@ ksh_getopt(char **argv, Getopt *go, const char *options)
  * No trailing newline is printed.
  */
 void
-print_value_quoted(const char *s)
+print_value_quoted(s)
+	const char *s;
 {
 	const char *p;
 	int inquote = 0;
@@ -1069,8 +1106,13 @@ print_value_quoted(const char *s)
  * element
  */
 void
-print_columns(struct shf *shf, int n, char *(*func)(void *, int, char *, int),
-			  void *arg, int max_width, int prefcol)
+print_columns(shf, n, func, arg, max_width, prefcol)
+	struct shf *shf;
+	int n;
+	char *(*func) ARGS((void *, int, char *, int));
+	void *arg;
+	int max_width;
+	int prefcol;
 {
 	char *str = (char *) alloc(max_width + 1, ATEMP);
 	int i;
@@ -1116,7 +1158,9 @@ print_columns(struct shf *shf, int n, char *(*func)(void *, int, char *, int),
 
 /* Strip any nul bytes from buf - returns new length (nbytes - # of nuls) */
 int
-strip_nuls(char *buf, int nbytes)
+strip_nuls(buf, nbytes)
+	char *buf;
+	int nbytes;
 {
 	char *dst;
 
@@ -1147,7 +1191,10 @@ strip_nuls(char *buf, int nbytes)
  * Returns dst.
  */
 char *
-str_zcpy(char *dst, const char *src, int dsize)
+str_zcpy(dst, src, dsize)
+	char *dst;
+	const char *src;
+	int dsize;
 {
 	if (dsize > 0) {
 		int len = strlen(src);
@@ -1164,7 +1211,10 @@ str_zcpy(char *dst, const char *src, int dsize)
  * and restarts read.
  */
 int
-blocking_read(int fd, char *buf, int nbytes)
+blocking_read(fd, buf, nbytes)
+	int fd;
+	char *buf;
+	int nbytes;
 {
 	int ret;
 	int tried_reset = 0;
@@ -1193,7 +1243,8 @@ blocking_read(int fd, char *buf, int nbytes)
  * 1 if it was.
  */
 int
-reset_nonblock(int fd)
+reset_nonblock(fd)
+	int fd;
 {
 	int flags;
 	int blocking_flags;
@@ -1249,7 +1300,9 @@ reset_nonblock(int fd)
 
 /* Like getcwd(), except bsize is ignored if buf is 0 (MAXPATHLEN is used) */
 char *
-ksh_get_wd(char *buf, int bsize)
+ksh_get_wd(buf, bsize)
+	char *buf;
+	int bsize;
 {
 #ifdef HAVE_GETCWD
 	char *b;
@@ -1309,4 +1362,3 @@ ksh_get_wd(char *buf, int bsize)
 	return b;
 #endif /* HAVE_GETCWD */
 }
-

--- a/bin/ksh/misc.c
+++ b/bin/ksh/misc.c
@@ -31,9 +31,7 @@ static const unsigned char *cclass ARGS((const unsigned char *p, int sub));
  * Fast character classes
  */
 void
-setctypes(s, t)
-	register const char *s;
-	register int t;
+setctypes(register const char *s, register int t)
 {
 	register int i;
 
@@ -47,7 +45,7 @@ setctypes(s, t)
 }
 
 void
-initctypes()
+initctypes(void)
 {
 	register int c;
 
@@ -68,9 +66,7 @@ initctypes()
 /* convert unsigned long to base N string */
 
 char *
-ulton(n, base)
-	register unsigned long n;
-	int base;
+ulton(register unsigned long n, int base)
 {
 	register char *p;
 	static char buf [20];
@@ -85,9 +81,7 @@ ulton(n, base)
 }
 
 char *
-str_save(s, ap)
-	register const char *s;
-	Area *ap;
+str_save(register const char *s, Area *ap)
 {
 	size_t len;
 	char *p;
@@ -105,10 +99,7 @@ str_save(s, ap)
  * (unless n < 0).
  */
 char *
-str_nsave(s, n, ap)
-	register const char *s;
-	int n;
-	Area *ap;
+str_nsave(register const char *s, int n, Area *ap)
 {
 	char *ns;
 
@@ -121,10 +112,7 @@ str_nsave(s, n, ap)
 
 /* called from expand.h:XcheckN() to grow buffer */
 char *
-Xcheck_grow_(xsp, xp, more)
-	XString *xsp;
-	char *xp;
-	int more;
+Xcheck_grow_(XString *xsp, char *xp, int more)
 {
 	char *old_beg = xsp->beg;
 
@@ -197,8 +185,7 @@ const struct option goptions[] = {
  * translate -o option into F* constant (also used for test -o option)
  */
 int
-option(n)
-	const char *n;
+option(const char *n)
 {
 	int i;
 
@@ -222,11 +209,7 @@ static void printoptions ARGS((int verbose));
 
 /* format a single select menu item */
 static char *
-options_fmt_entry(arg, i, buf, buflen)
-	void *arg;
-	int i;
-	char *buf;
-	int buflen;
+options_fmt_entry(void *arg, int i, char *buf, int buflen)
 {
 	struct options_info *oi = (struct options_info *) arg;
 
@@ -237,8 +220,7 @@ options_fmt_entry(arg, i, buf, buflen)
 }
 
 static void
-printoptions(verbose)
-	int verbose;
+printoptions(int verbose)
 {
 	int i;
 
@@ -270,7 +252,7 @@ printoptions(verbose)
 }
 
 char *
-getoptions()
+getoptions(void)
 {
 	size_t i;
 	char m[(int) FNFLAGS + 1];
@@ -283,12 +265,14 @@ getoptions()
 	return str_save(m, ATEMP);
 }
 
-/* change a Flag(*) value; takes care of special actions */
+/* change a Flag(*) value; takes care of special actions
+ *
+ * f - flag to change
+ * what - what is changing the flag (command line vs set)
+ *
+ */
 void
-change_flag(f, what, newval)
-	enum sh_flag f;	/* flag to change */
-	int what;	/* what is changing the flag (command line vs set) */
-	int newval;
+change_flag(enum sh_flag f, int what, int newval)
 {
 	int oldval;
 
@@ -346,12 +330,11 @@ change_flag(f, what, newval)
 
 /* parse command line & set command arguments.  returns the index of
  * non-option arguments, -1 if there is an error.
+ *
+ * what - OF_CMDLINE or OF_SET
  */
 int
-parse_args(argv, what, setargsp)
-	char **argv;
-	int	what;		/* OF_CMDLINE or OF_SET */
-	int	*setargsp;
+parse_args(char **argv, int what, int *setargsp)
 {
 	static char cmd_opts[NELEM(goptions) + 3]; /* o:\0 */
 	static char set_opts[NELEM(goptions) + 5]; /* Ao;s\0 */
@@ -488,9 +471,7 @@ parse_args(argv, what, setargsp)
 
 /* parse a decimal number: returns 0 if string isn't a number, 1 otherwise */
 int
-getn(as, ai)
-	const char *as;
-	int *ai;
+getn(const char *as, int *ai)
 {
 	char *p;
 	long n;
@@ -506,9 +487,7 @@ getn(as, ai)
 
 /* getn() that prints error */
 int
-bi_getn(as, ai)
-	const char *as;
-	int *ai;
+bi_getn(const char *as, int *ai)
 {
 	int rv = getn(as, ai);
 
@@ -528,9 +507,7 @@ bi_getn(as, ai)
  */
 
 int
-gmatch(s, p, isfile)
-	const char *s, *p;
-	int isfile;
+gmatch(const char *s, const char *p, int isfile)
 {
 	const char *se, *pe;
 
@@ -571,8 +548,7 @@ gmatch(s, p, isfile)
 - return ?
 */
 int
-has_globbing(xp, xpe)
-	const char *xp, *xpe;
+has_globbing(const char *xp, const char *xpe)
 {
 	const unsigned char *p = (const unsigned char *) xp;
 	const unsigned char *pe = (const unsigned char *) xpe;
@@ -626,10 +602,9 @@ has_globbing(xp, xpe)
 
 /* Function must return either 0 or 1 (assumed by code for 0x80|'!') */
 static int
-do_gmatch(s, se, p, pe, isfile)
-	const unsigned char *s, *p;
-	const unsigned char *se, *pe;
-	int isfile;
+do_gmatch(const unsigned char *s, const unsigned char *se,
+		  const unsigned char *p, const unsigned char *pe,
+		  int isfile)
 {
 	register int sc, pc;
 	const unsigned char *prest, *psub, *pnext;
@@ -761,9 +736,7 @@ do_gmatch(s, se, p, pe, isfile)
 }
 
 static const unsigned char *
-cclass(p, sub)
-	const unsigned char *p;
-	register int sub;
+cclass(const unsigned char *p, register int sub)
 {
 	register int c, d, not, found = 0;
 	const unsigned char *orig_p = p;
@@ -808,10 +781,7 @@ cclass(p, sub)
 
 /* Look for next ) or | (if match_sep) in *(foo|bar) pattern */
 const unsigned char *
-pat_scan(p, pe, match_sep)
-	const unsigned char *p;
-	const unsigned char *pe;
-	int match_sep;
+pat_scan(const unsigned char *p, const unsigned char *pe, int match_sep)
 {
 	int nest = 0;
 
@@ -835,11 +805,13 @@ pat_scan(p, pe, match_sep)
  */
 static void qsort1 ARGS((void **base, void **lim, int (*f)(void *, void *)));
 
+/*
+ * base - base address
+ * n - elements
+ * f - compare function
+ */
 void
-qsortp(base, n, f)
-	void **base;				/* base address */
-	size_t n;				/* elements */
-	int (*f) ARGS((void *, void *));	/* compare function */
+qsortp(void **base, size_t n, int (*f)(void*, void*))
 {
 	qsort1(base, base + n, f);
 }
@@ -852,9 +824,7 @@ qsortp(base, n, f)
 }
 
 static void
-qsort1(base, lim, f)
-	void **base, **lim;
-	int (*f) ARGS((void *, void *));
+qsort1(void **base, void **lim, int (*f)(void *, void *))
 {
 	register void **i, **j;
 	register void **lptr, **hptr;
@@ -923,17 +893,14 @@ qsort1(base, lim, f)
 }
 
 int
-xstrcmp(p1, p2)
-	void *p1, *p2;
+xstrcmp(void *p1, void *p2)
 {
 	return (strcmp((char *)p1, (char *)p2));
 }
 
 /* Initialize a Getopt structure */
 void
-ksh_getopt_reset(go, flags)
-	Getopt *go;
-	int flags;
+ksh_getopt_reset(Getopt *go, int flags)
 {
 	go->optind = 1;
 	go->optarg = (char *) 0;
@@ -969,10 +936,7 @@ ksh_getopt_reset(go, flags)
  *	  in go->info.
  */
 int
-ksh_getopt(argv, go, options)
-	char **argv;
-	Getopt *go;
-	const char *options;
+ksh_getopt(char **argv, Getopt *go, const char *options)
 {
 	char c;
 	char *o;
@@ -1072,8 +1036,7 @@ ksh_getopt(argv, go, options)
  * No trailing newline is printed.
  */
 void
-print_value_quoted(s)
-	const char *s;
+print_value_quoted(const char *s)
 {
 	const char *p;
 	int inquote = 0;
@@ -1106,13 +1069,8 @@ print_value_quoted(s)
  * element
  */
 void
-print_columns(shf, n, func, arg, max_width, prefcol)
-	struct shf *shf;
-	int n;
-	char *(*func) ARGS((void *, int, char *, int));
-	void *arg;
-	int max_width;
-	int prefcol;
+print_columns(struct shf *shf, int n, char *(*func)(void *, int, char *, int),
+			  void *arg, int max_width, int prefcol)
 {
 	char *str = (char *) alloc(max_width + 1, ATEMP);
 	int i;
@@ -1158,9 +1116,7 @@ print_columns(shf, n, func, arg, max_width, prefcol)
 
 /* Strip any nul bytes from buf - returns new length (nbytes - # of nuls) */
 int
-strip_nuls(buf, nbytes)
-	char *buf;
-	int nbytes;
+strip_nuls(char *buf, int nbytes)
 {
 	char *dst;
 
@@ -1191,10 +1147,7 @@ strip_nuls(buf, nbytes)
  * Returns dst.
  */
 char *
-str_zcpy(dst, src, dsize)
-	char *dst;
-	const char *src;
-	int dsize;
+str_zcpy(char *dst, const char *src, int dsize)
 {
 	if (dsize > 0) {
 		int len = strlen(src);
@@ -1211,10 +1164,7 @@ str_zcpy(dst, src, dsize)
  * and restarts read.
  */
 int
-blocking_read(fd, buf, nbytes)
-	int fd;
-	char *buf;
-	int nbytes;
+blocking_read(int fd, char *buf, int nbytes)
 {
 	int ret;
 	int tried_reset = 0;
@@ -1243,8 +1193,7 @@ blocking_read(fd, buf, nbytes)
  * 1 if it was.
  */
 int
-reset_nonblock(fd)
-	int fd;
+reset_nonblock(int fd)
 {
 	int flags;
 	int blocking_flags;
@@ -1300,9 +1249,7 @@ reset_nonblock(fd)
 
 /* Like getcwd(), except bsize is ignored if buf is 0 (MAXPATHLEN is used) */
 char *
-ksh_get_wd(buf, bsize)
-	char *buf;
-	int bsize;
+ksh_get_wd(char *buf, int bsize)
 {
 #ifdef HAVE_GETCWD
 	char *b;
@@ -1362,3 +1309,4 @@ ksh_get_wd(buf, bsize)
 	return b;
 #endif /* HAVE_GETCWD */
 }
+

--- a/bin/ksh/path.c
+++ b/bin/ksh/path.c
@@ -36,14 +36,12 @@ static char	*do_phys_path ARGS((XString *, char *, const char *));
  *	  if there are no more elements.
  *	The return value indicates whether a non-null element from cdpathp
  *	was appended to result.
+ *
+ *	cdpathp - & of : separated list
  */
 int
-make_path(cwd, file, cdpathp, xsp, phys_pathp)
-	const char *cwd;
-	const char *file;
-	char	**cdpathp;	/* & of : separated list */
-	XString	*xsp;
-	int	*phys_pathp;
+make_path(const char *cwd, const char *file, char **cdpathp, XString *xsp,
+		  int *phys_pathp)
 {
 	int	rval = 0;
 	int	use_cdpath = 1;
@@ -116,8 +114,7 @@ make_path(cwd, file, cdpathp, xsp, phys_pathp)
  * ie, simplify_path("/a/b/c/./../d/..") returns "/a/b"
  */
 void
-simplify_path(pathx)
-	char	*pathx;
+simplify_path(char *pathx)
 {
 	char	*cur;
 	char	*t;
@@ -199,8 +196,7 @@ simplify_path(pathx)
 
 
 void
-set_current_wd(pathx)
-	char *pathx;
+set_current_wd(char *pathx)
 {
 	int len;
 	char *p = pathx;
@@ -219,8 +215,7 @@ set_current_wd(pathx)
 
 #ifdef S_ISLNK
 char *
-get_phys_path(pathx)
-	const char *pathx;
+get_phys_path(const char *pathx)
 {
 	XString xs;
 	char *xp;
@@ -240,10 +235,7 @@ get_phys_path(pathx)
 }
 
 static char *
-do_phys_path(xsp, xp, pathx)
-	XString *xsp;
-	char *xp;
-	const char *pathx;
+do_phys_path(XString *xsp, char *xp, const char *pathx)
 {
 	const char *p, *q;
 	int len, llen;
@@ -296,7 +288,7 @@ do_phys_path(xsp, xp, pathx)
 
 #ifdef	TEST
 
-main(argc, argv)
+main(int argc, char **argv)
 {
 	int	rv;
 	char	*cp, cdpath[256], pwd[256], file[256], result[256];
@@ -316,3 +308,4 @@ main(argc, argv)
 	}
 }
 #endif	/* TEST */
+

--- a/bin/ksh/path.c
+++ b/bin/ksh/path.c
@@ -36,12 +36,14 @@ static char	*do_phys_path ARGS((XString *, char *, const char *));
  *	  if there are no more elements.
  *	The return value indicates whether a non-null element from cdpathp
  *	was appended to result.
- *
- *	cdpathp - & of : separated list
  */
 int
-make_path(const char *cwd, const char *file, char **cdpathp, XString *xsp,
-		  int *phys_pathp)
+make_path(cwd, file, cdpathp, xsp, phys_pathp)
+	const char *cwd;
+	const char *file;
+	char	**cdpathp;	/* & of : separated list */
+	XString	*xsp;
+	int	*phys_pathp;
 {
 	int	rval = 0;
 	int	use_cdpath = 1;
@@ -114,7 +116,8 @@ make_path(const char *cwd, const char *file, char **cdpathp, XString *xsp,
  * ie, simplify_path("/a/b/c/./../d/..") returns "/a/b"
  */
 void
-simplify_path(char *pathx)
+simplify_path(pathx)
+	char	*pathx;
 {
 	char	*cur;
 	char	*t;
@@ -196,7 +199,8 @@ simplify_path(char *pathx)
 
 
 void
-set_current_wd(char *pathx)
+set_current_wd(pathx)
+	char *pathx;
 {
 	int len;
 	char *p = pathx;
@@ -215,7 +219,8 @@ set_current_wd(char *pathx)
 
 #ifdef S_ISLNK
 char *
-get_phys_path(const char *pathx)
+get_phys_path(pathx)
+	const char *pathx;
 {
 	XString xs;
 	char *xp;
@@ -235,7 +240,10 @@ get_phys_path(const char *pathx)
 }
 
 static char *
-do_phys_path(XString *xsp, char *xp, const char *pathx)
+do_phys_path(xsp, xp, pathx)
+	XString *xsp;
+	char *xp;
+	const char *pathx;
 {
 	const char *p, *q;
 	int len, llen;
@@ -288,7 +296,7 @@ do_phys_path(XString *xsp, char *xp, const char *pathx)
 
 #ifdef	TEST
 
-main(int argc, char **argv)
+main(argc, argv)
 {
 	int	rv;
 	char	*cp, cdpath[256], pwd[256], file[256], result[256];
@@ -308,4 +316,3 @@ main(int argc, char **argv)
 	}
 }
 #endif	/* TEST */
-

--- a/bin/ksh/proto.h
+++ b/bin/ksh/proto.h
@@ -296,3 +296,4 @@ extern int gettimeofday ARGS(( /* struct timeval *, struct timezone * */ ));
 extern int setrlimit ARGS(( /* int, struct rlimit * */ ));
 extern int lstat ARGS(( /* const char *, struct stat * */ ));
 #endif
+

--- a/bin/ksh/proto.h
+++ b/bin/ksh/proto.h
@@ -296,4 +296,3 @@ extern int gettimeofday ARGS(( /* struct timeval *, struct timezone * */ ));
 extern int setrlimit ARGS(( /* int, struct rlimit * */ ));
 extern int lstat ARGS(( /* const char *, struct stat * */ ));
 #endif
-

--- a/bin/ksh/sh.h
+++ b/bin/ksh/sh.h
@@ -733,3 +733,4 @@ EXTERN	int	x_cols I__(80);	/* tty columns */
 # undef EXTERN
 #endif
 #undef I__
+

--- a/bin/ksh/sh.h
+++ b/bin/ksh/sh.h
@@ -733,4 +733,3 @@ EXTERN	int	x_cols I__(80);	/* tty columns */
 # undef EXTERN
 #endif
 #undef I__
-

--- a/bin/ksh/shf.c
+++ b/bin/ksh/shf.c
@@ -33,7 +33,11 @@ static int	shf_emptybuf	ARGS((struct shf *shf, int flags));
  * fails.
  */
 struct shf *
-shf_open(const char *name, int oflags, int mode, int sflags)
+shf_open(name, oflags, mode, sflags)
+	const char *name;
+	int oflags;
+	int mode;
+	int sflags;
 {
 	struct shf *shf;
 	int bsize = sflags & SHF_UNBUF ? (sflags & SHF_RD ? 1 : 0) : SHF_BSIZE;
@@ -73,7 +77,10 @@ shf_open(const char *name, int oflags, int mode, int sflags)
 
 /* Set up the shf structure for a file descriptor.  Doesn't fail. */
 struct shf *
-shf_fdopen(int fd, int sflags, struct shf *shf)
+shf_fdopen(fd, sflags, shf)
+	int fd;
+	int sflags;
+	struct shf *shf;
 {
 	int bsize = sflags & SHF_UNBUF ? (sflags & SHF_RD ? 1 : 0) : SHF_BSIZE;
 
@@ -123,7 +130,10 @@ shf_fdopen(int fd, int sflags, struct shf *shf)
 
 /* Set up an existing shf (and buffer) to use the given fd */
 struct shf *
-shf_reopen(int fd, int sflags, struct shf *shf)
+shf_reopen(fd, sflags, shf)
+	int fd;
+	int sflags;
+	struct shf *shf;
 {
 	int bsize = sflags & SHF_UNBUF ? (sflags & SHF_RD ? 1 : 0) : SHF_BSIZE;
 
@@ -170,7 +180,11 @@ shf_reopen(int fd, int sflags, struct shf *shf)
  * When writing, a byte is reserved for a trailing null - see shf_sclose().
  */
 struct shf *
-shf_sopen(char *buf, int bsize, int sflags, struct shf *shf)
+shf_sopen(buf, bsize, sflags, shf)
+	char *buf;
+	int bsize;
+	int sflags;
+	struct shf *shf;
 {
 	/* can't have a read+write string */
 	if (!(sflags & (SHF_RD | SHF_WR))
@@ -203,7 +217,8 @@ shf_sopen(char *buf, int bsize, int sflags, struct shf *shf)
 
 /* Flush and close file descriptor, free the shf structure */
 int
-shf_close(struct shf *shf)
+shf_close(shf)
+	struct shf *shf;
 {
 	int ret = 0;
 
@@ -222,7 +237,8 @@ shf_close(struct shf *shf)
 
 /* Flush and close file descriptor, don't free file structure */
 int
-shf_fdclose(struct shf *shf)
+shf_fdclose(shf)
+	struct shf *shf;
 {
 	int ret = 0;
 
@@ -244,7 +260,8 @@ shf_fdclose(struct shf *shf)
  * (does not free string if it was allocated).
  */
 char *
-shf_sclose(struct shf *shf)
+shf_sclose(shf)
+	struct shf *shf;
 {
 	unsigned char *s = shf->buf;
 
@@ -260,7 +277,8 @@ shf_sclose(struct shf *shf)
 
 /* Flush and free file structure, don't close file descriptor */
 int
-shf_finish(struct shf *shf)
+shf_finish(shf)
+	struct shf *shf;
 {
 	int ret = 0;
 
@@ -278,7 +296,8 @@ shf_finish(struct shf *shf)
  * buffered.  Returns 0 for success, EOF for (write) error.
  */
 int
-shf_flush(struct shf *shf)
+shf_flush(shf)
+	struct shf *shf;
 {
 	if (shf->flags & SHF_STRING)
 		return (shf->flags & SHF_WR) ? EOF : 0;
@@ -309,7 +328,9 @@ shf_flush(struct shf *shf)
  * buffer.  Returns 0 for success, EOF for (write) error.
  */
 static int
-shf_emptybuf(struct shf *shf, int flags)
+shf_emptybuf(shf, flags)
+	struct shf *shf;
+	int flags;
 {
 	int ret = 0;
 
@@ -389,7 +410,8 @@ shf_emptybuf(struct shf *shf, int flags)
 
 /* Fill up a read buffer.  Returns EOF for a read error, 0 otherwise. */
 static int
-shf_fillbuf(struct shf *shf)
+shf_fillbuf(shf)
+	struct shf *shf;
 {
 	if (shf->flags & SHF_STRING)
 		return 0;
@@ -435,7 +457,10 @@ shf_fillbuf(struct shf *shf)
  * buffer.  Returns 0 for success, EOF otherwise.
  */
 int
-shf_seek(struct shf *shf, off_t where, int from)
+shf_seek(shf, where, from)
+	struct shf *shf;
+	off_t where;
+	int from;
 {
 	if (shf->fd < 0) {
 		errno = EINVAL;
@@ -480,7 +505,10 @@ shf_seek(struct shf *shf, off_t where, int from)
  * a read error occurred.
  */
 int
-shf_read(char *buf, int bsize, struct shf *shf)
+shf_read(buf, bsize, shf)
+	char *buf;
+	int bsize;
+	struct shf *shf;
 {
 	int orig_bsize = bsize;
 	int ncopy;
@@ -514,7 +542,10 @@ shf_read(char *buf, int bsize, struct shf *shf)
  * end of file, returns a pointer to the null byte in buf otherwise.
  */
 char *
-shf_getse(char *buf, int bsize, struct shf *shf)
+shf_getse(buf, bsize, shf)
+	char *buf;
+	int bsize;
+	struct shf *shf;
 {
 	unsigned char *end;
 	int ncopy;
@@ -561,7 +592,8 @@ shf_getse(char *buf, int bsize, struct shf *shf)
 
 /* Returns the char read.  Returns EOF for error and end of file. */
 int
-shf_getchar(struct shf *shf)
+shf_getchar(shf)
+	struct shf *shf;
 {
 	if (!(shf->flags & SHF_RD))
 		internal_errorf(1, "shf_getchar: flags %x", shf->flags);
@@ -576,7 +608,9 @@ shf_getchar(struct shf *shf)
  * successful, EOF if there is no room.
  */
 int
-shf_ungetc(int c, struct shf *shf)
+shf_ungetc(c, shf)
+	int c;
+	struct shf *shf;
 {
 	if (!(shf->flags & SHF_RD))
 		internal_errorf(1, "shf_ungetc: flags %x", shf->flags);
@@ -611,7 +645,9 @@ shf_ungetc(int c, struct shf *shf)
  * the char could not be written.
  */
 int
-shf_putchar(int c, struct shf *shf)
+shf_putchar(c, shf)
+	int c;
+	struct shf *shf;
 {
 	if (!(shf->flags & SHF_WR))
 		internal_errorf(1, "shf_putchar: flags %x", shf->flags);
@@ -653,7 +689,9 @@ shf_putchar(int c, struct shf *shf)
  * the string could not be written.
  */
 int
-shf_puts(const char *s, struct  shf *shf)
+shf_puts(s, shf)
+	const char *s;
+	struct shf *shf;
 {
 	if (!s)
 		return EOF;
@@ -663,7 +701,10 @@ shf_puts(const char *s, struct  shf *shf)
 
 /* Write a buffer.  Returns nbytes if successful, EOF if there is an error. */
 int
-shf_write(const char *buf, int nbytes, struct shf *shf)
+shf_write(buf, nbytes, shf)
+	const char *buf;
+	int nbytes;
+	struct shf *shf;
 {
 	int orig_nbytes = nbytes;
 	int n;
@@ -724,7 +765,14 @@ shf_write(const char *buf, int nbytes, struct shf *shf)
 }
 
 int
+#ifdef HAVE_PROTOTYPES
 shf_fprintf(struct shf *shf, const char *fmt, ...)
+#else
+shf_fprintf(shf, fmt, va_alist)
+	struct shf *shf;
+	const char *fmt;
+	va_dcl
+#endif
 {
 	va_list args;
 	int n;
@@ -737,7 +785,15 @@ shf_fprintf(struct shf *shf, const char *fmt, ...)
 }
 
 int
+#ifdef HAVE_PROTOTYPES
 shf_snprintf(char *buf, int bsize, const char *fmt, ...)
+#else
+shf_snprintf(buf, bsize, fmt, va_alist)
+	char *buf;
+	int bsize;
+	const char *fmt;
+	va_dcl
+#endif
 {
 	struct shf shf;
 	va_list args;
@@ -756,7 +812,13 @@ shf_snprintf(char *buf, int bsize, const char *fmt, ...)
 }
 
 char *
+#ifdef HAVE_PROTOTYPES
 shf_smprintf(const char *fmt, ...)
+#else
+shf_smprintf(fmt, va_alist)
+	char *fmt;
+	va_dcl
+#endif
 {
 	struct shf shf;
 	va_list args;
@@ -816,7 +878,8 @@ shf_smprintf(const char *fmt, ...)
 #include <math.h>
 
 static double
-my_ceil(double d)
+my_ceil(d)
+	double	d;
 {
 	double		i;
 
@@ -825,7 +888,10 @@ my_ceil(double d)
 #endif /* FP */
 
 int
-shf_vfprintf(struct shf *shf, const char *fmt, va_list args)
+shf_vfprintf(shf, fmt, args)
+	struct shf *shf;
+	const char *fmt;
+	va_list args;
 {
 	char		c, *s;
 	int		UNINITIALIZED(tmp);
@@ -1234,4 +1300,3 @@ shf_vfprintf(struct shf *shf, const char *fmt, va_list args)
 
 	return shf_error(shf) ? EOF : nwritten;
 }
-

--- a/bin/ksh/shf.c
+++ b/bin/ksh/shf.c
@@ -33,11 +33,7 @@ static int	shf_emptybuf	ARGS((struct shf *shf, int flags));
  * fails.
  */
 struct shf *
-shf_open(name, oflags, mode, sflags)
-	const char *name;
-	int oflags;
-	int mode;
-	int sflags;
+shf_open(const char *name, int oflags, int mode, int sflags)
 {
 	struct shf *shf;
 	int bsize = sflags & SHF_UNBUF ? (sflags & SHF_RD ? 1 : 0) : SHF_BSIZE;
@@ -77,10 +73,7 @@ shf_open(name, oflags, mode, sflags)
 
 /* Set up the shf structure for a file descriptor.  Doesn't fail. */
 struct shf *
-shf_fdopen(fd, sflags, shf)
-	int fd;
-	int sflags;
-	struct shf *shf;
+shf_fdopen(int fd, int sflags, struct shf *shf)
 {
 	int bsize = sflags & SHF_UNBUF ? (sflags & SHF_RD ? 1 : 0) : SHF_BSIZE;
 
@@ -130,10 +123,7 @@ shf_fdopen(fd, sflags, shf)
 
 /* Set up an existing shf (and buffer) to use the given fd */
 struct shf *
-shf_reopen(fd, sflags, shf)
-	int fd;
-	int sflags;
-	struct shf *shf;
+shf_reopen(int fd, int sflags, struct shf *shf)
 {
 	int bsize = sflags & SHF_UNBUF ? (sflags & SHF_RD ? 1 : 0) : SHF_BSIZE;
 
@@ -180,11 +170,7 @@ shf_reopen(fd, sflags, shf)
  * When writing, a byte is reserved for a trailing null - see shf_sclose().
  */
 struct shf *
-shf_sopen(buf, bsize, sflags, shf)
-	char *buf;
-	int bsize;
-	int sflags;
-	struct shf *shf;
+shf_sopen(char *buf, int bsize, int sflags, struct shf *shf)
 {
 	/* can't have a read+write string */
 	if (!(sflags & (SHF_RD | SHF_WR))
@@ -217,8 +203,7 @@ shf_sopen(buf, bsize, sflags, shf)
 
 /* Flush and close file descriptor, free the shf structure */
 int
-shf_close(shf)
-	struct shf *shf;
+shf_close(struct shf *shf)
 {
 	int ret = 0;
 
@@ -237,8 +222,7 @@ shf_close(shf)
 
 /* Flush and close file descriptor, don't free file structure */
 int
-shf_fdclose(shf)
-	struct shf *shf;
+shf_fdclose(struct shf *shf)
 {
 	int ret = 0;
 
@@ -260,8 +244,7 @@ shf_fdclose(shf)
  * (does not free string if it was allocated).
  */
 char *
-shf_sclose(shf)
-	struct shf *shf;
+shf_sclose(struct shf *shf)
 {
 	unsigned char *s = shf->buf;
 
@@ -277,8 +260,7 @@ shf_sclose(shf)
 
 /* Flush and free file structure, don't close file descriptor */
 int
-shf_finish(shf)
-	struct shf *shf;
+shf_finish(struct shf *shf)
 {
 	int ret = 0;
 
@@ -296,8 +278,7 @@ shf_finish(shf)
  * buffered.  Returns 0 for success, EOF for (write) error.
  */
 int
-shf_flush(shf)
-	struct shf *shf;
+shf_flush(struct shf *shf)
 {
 	if (shf->flags & SHF_STRING)
 		return (shf->flags & SHF_WR) ? EOF : 0;
@@ -328,9 +309,7 @@ shf_flush(shf)
  * buffer.  Returns 0 for success, EOF for (write) error.
  */
 static int
-shf_emptybuf(shf, flags)
-	struct shf *shf;
-	int flags;
+shf_emptybuf(struct shf *shf, int flags)
 {
 	int ret = 0;
 
@@ -410,8 +389,7 @@ shf_emptybuf(shf, flags)
 
 /* Fill up a read buffer.  Returns EOF for a read error, 0 otherwise. */
 static int
-shf_fillbuf(shf)
-	struct shf *shf;
+shf_fillbuf(struct shf *shf)
 {
 	if (shf->flags & SHF_STRING)
 		return 0;
@@ -457,10 +435,7 @@ shf_fillbuf(shf)
  * buffer.  Returns 0 for success, EOF otherwise.
  */
 int
-shf_seek(shf, where, from)
-	struct shf *shf;
-	off_t where;
-	int from;
+shf_seek(struct shf *shf, off_t where, int from)
 {
 	if (shf->fd < 0) {
 		errno = EINVAL;
@@ -505,10 +480,7 @@ shf_seek(shf, where, from)
  * a read error occurred.
  */
 int
-shf_read(buf, bsize, shf)
-	char *buf;
-	int bsize;
-	struct shf *shf;
+shf_read(char *buf, int bsize, struct shf *shf)
 {
 	int orig_bsize = bsize;
 	int ncopy;
@@ -542,10 +514,7 @@ shf_read(buf, bsize, shf)
  * end of file, returns a pointer to the null byte in buf otherwise.
  */
 char *
-shf_getse(buf, bsize, shf)
-	char *buf;
-	int bsize;
-	struct shf *shf;
+shf_getse(char *buf, int bsize, struct shf *shf)
 {
 	unsigned char *end;
 	int ncopy;
@@ -592,8 +561,7 @@ shf_getse(buf, bsize, shf)
 
 /* Returns the char read.  Returns EOF for error and end of file. */
 int
-shf_getchar(shf)
-	struct shf *shf;
+shf_getchar(struct shf *shf)
 {
 	if (!(shf->flags & SHF_RD))
 		internal_errorf(1, "shf_getchar: flags %x", shf->flags);
@@ -608,9 +576,7 @@ shf_getchar(shf)
  * successful, EOF if there is no room.
  */
 int
-shf_ungetc(c, shf)
-	int c;
-	struct shf *shf;
+shf_ungetc(int c, struct shf *shf)
 {
 	if (!(shf->flags & SHF_RD))
 		internal_errorf(1, "shf_ungetc: flags %x", shf->flags);
@@ -645,9 +611,7 @@ shf_ungetc(c, shf)
  * the char could not be written.
  */
 int
-shf_putchar(c, shf)
-	int c;
-	struct shf *shf;
+shf_putchar(int c, struct shf *shf)
 {
 	if (!(shf->flags & SHF_WR))
 		internal_errorf(1, "shf_putchar: flags %x", shf->flags);
@@ -689,9 +653,7 @@ shf_putchar(c, shf)
  * the string could not be written.
  */
 int
-shf_puts(s, shf)
-	const char *s;
-	struct shf *shf;
+shf_puts(const char *s, struct  shf *shf)
 {
 	if (!s)
 		return EOF;
@@ -701,10 +663,7 @@ shf_puts(s, shf)
 
 /* Write a buffer.  Returns nbytes if successful, EOF if there is an error. */
 int
-shf_write(buf, nbytes, shf)
-	const char *buf;
-	int nbytes;
-	struct shf *shf;
+shf_write(const char *buf, int nbytes, struct shf *shf)
 {
 	int orig_nbytes = nbytes;
 	int n;
@@ -765,14 +724,7 @@ shf_write(buf, nbytes, shf)
 }
 
 int
-#ifdef HAVE_PROTOTYPES
 shf_fprintf(struct shf *shf, const char *fmt, ...)
-#else
-shf_fprintf(shf, fmt, va_alist)
-	struct shf *shf;
-	const char *fmt;
-	va_dcl
-#endif
 {
 	va_list args;
 	int n;
@@ -785,15 +737,7 @@ shf_fprintf(shf, fmt, va_alist)
 }
 
 int
-#ifdef HAVE_PROTOTYPES
 shf_snprintf(char *buf, int bsize, const char *fmt, ...)
-#else
-shf_snprintf(buf, bsize, fmt, va_alist)
-	char *buf;
-	int bsize;
-	const char *fmt;
-	va_dcl
-#endif
 {
 	struct shf shf;
 	va_list args;
@@ -812,13 +756,7 @@ shf_snprintf(buf, bsize, fmt, va_alist)
 }
 
 char *
-#ifdef HAVE_PROTOTYPES
 shf_smprintf(const char *fmt, ...)
-#else
-shf_smprintf(fmt, va_alist)
-	char *fmt;
-	va_dcl
-#endif
 {
 	struct shf shf;
 	va_list args;
@@ -878,8 +816,7 @@ shf_smprintf(fmt, va_alist)
 #include <math.h>
 
 static double
-my_ceil(d)
-	double	d;
+my_ceil(double d)
 {
 	double		i;
 
@@ -888,10 +825,7 @@ my_ceil(d)
 #endif /* FP */
 
 int
-shf_vfprintf(shf, fmt, args)
-	struct shf *shf;
-	const char *fmt;
-	va_list args;
+shf_vfprintf(struct shf *shf, const char *fmt, va_list args)
 {
 	char		c, *s;
 	int		UNINITIALIZED(tmp);
@@ -1300,3 +1234,4 @@ shf_vfprintf(shf, fmt, args)
 
 	return shf_error(shf) ? EOF : nwritten;
 }
+

--- a/bin/ksh/shf.h
+++ b/bin/ksh/shf.h
@@ -85,4 +85,3 @@ char	    *shf_smprintf ARGS((const char *fmt, ...));
 int	    shf_vfprintf ARGS((struct shf *, const char *fmt, va_list args));
 
 #endif /* SHF_H */
-

--- a/bin/ksh/shf.h
+++ b/bin/ksh/shf.h
@@ -85,3 +85,4 @@ char	    *shf_smprintf ARGS((const char *fmt, ...));
 int	    shf_vfprintf ARGS((struct shf *, const char *fmt, va_list args));
 
 #endif /* SHF_H */
+

--- a/bin/ksh/sigact.c
+++ b/bin/ksh/sigact.c
@@ -209,9 +209,7 @@ error must know what to implement with
 
  
 int
-sigaction(sig, act, oact)
-  int sig;
-  struct sigaction *act, *oact;
+sigaction(int sig, struct sigaction *act, struct sigaction *oact)
 {
   handler_t oldh;
 
@@ -261,9 +259,7 @@ sigaction(sig, act, oact)
 
 
 int
-sigaddset(mask, sig)
-  sigset_t *mask;
-  int sig;
+sigaddset(sigset_t *mask, int sig)
 {
   *mask |= sigmask(sig);
   return 0;
@@ -272,9 +268,7 @@ sigaddset(mask, sig)
 
 #ifndef IS_KSH
 int
-sigdelset(mask, sig)
-  sigset_t *mask;
-  int sig;
+sigdelset(sigset_t *mask, int sig)
 {
   *mask &= ~(sigmask(sig));
   return 0;
@@ -283,8 +277,7 @@ sigdelset(mask, sig)
 
 
 int
-sigemptyset(mask)
-  sigset_t *mask;
+sigemptyset(sigset_t *mask)
 {
   *mask = 0;
   return 0;
@@ -293,8 +286,7 @@ sigemptyset(mask)
 
 #ifndef IS_KSH
 int
-sigfillset(mask)
-  sigset_t *mask;
+sigfillset(sigset_t *mask)
 {
   *mask = ~0;
   return 0;
@@ -304,9 +296,7 @@ sigfillset(mask)
 
 #ifndef IS_KSH
 int
-sigismember(mask, sig)
-  sigset_t *mask;
-  int sig;
+sigismember(sigset_t *mask, int sig)
 {
   return ((*mask) & sigmask(sig));
 }
@@ -315,8 +305,7 @@ sigismember(mask, sig)
 
 #ifndef IS_KSH
 int
-sigpending(set)
-  sigset_t *set;
+sigpending(sigset_t *set)
 {
   return 0;				/* faking it! */
 }
@@ -324,9 +313,7 @@ sigpending(set)
 
 
 int
-sigprocmask(how, set, oset)
-  int how;
-  sigset_t *set, *oset;
+sigprocmask(int how, sigset_t *set, sigset_t *oset)
 {
 #ifdef USE_SIGSET
   register int i;
@@ -390,8 +377,7 @@ sigprocmask(how, set, oset)
 
 
 int
-sigsuspend(mask)
-  sigset_t *mask;
+sigsuspend(sigset_t *mask)
 {
 #ifdef USE_SIGMASK
   sigpause(*mask);
@@ -447,9 +433,8 @@ sigsuspend(mask)
  */
 
 #ifndef IS_KSH
-handler_t Signal(sig, handler)
-  int sig;
-  handler_t handler;
+handler_t
+Signal(int sig, handler_t handler)
 {
   struct sigaction act, oact;
 
@@ -468,9 +453,8 @@ handler_t Signal(sig, handler)
  * ensure we avoid signal mayhem
  */
 
-handler_t signal(sig, handler)
-  int sig;
-  handler_t handler;
+handler_t
+signal(int sig, handler_t handler)
 {
   return (Signal(sig, handler));
 }
@@ -484,3 +468,4 @@ handler_t signal(sig, handler)
  * comment-column:40
  * End:
  */
+

--- a/bin/ksh/sigact.c
+++ b/bin/ksh/sigact.c
@@ -209,7 +209,9 @@ error must know what to implement with
 
  
 int
-sigaction(int sig, struct sigaction *act, struct sigaction *oact)
+sigaction(sig, act, oact)
+  int sig;
+  struct sigaction *act, *oact;
 {
   handler_t oldh;
 
@@ -259,7 +261,9 @@ sigaction(int sig, struct sigaction *act, struct sigaction *oact)
 
 
 int
-sigaddset(sigset_t *mask, int sig)
+sigaddset(mask, sig)
+  sigset_t *mask;
+  int sig;
 {
   *mask |= sigmask(sig);
   return 0;
@@ -268,7 +272,9 @@ sigaddset(sigset_t *mask, int sig)
 
 #ifndef IS_KSH
 int
-sigdelset(sigset_t *mask, int sig)
+sigdelset(mask, sig)
+  sigset_t *mask;
+  int sig;
 {
   *mask &= ~(sigmask(sig));
   return 0;
@@ -277,7 +283,8 @@ sigdelset(sigset_t *mask, int sig)
 
 
 int
-sigemptyset(sigset_t *mask)
+sigemptyset(mask)
+  sigset_t *mask;
 {
   *mask = 0;
   return 0;
@@ -286,7 +293,8 @@ sigemptyset(sigset_t *mask)
 
 #ifndef IS_KSH
 int
-sigfillset(sigset_t *mask)
+sigfillset(mask)
+  sigset_t *mask;
 {
   *mask = ~0;
   return 0;
@@ -296,7 +304,9 @@ sigfillset(sigset_t *mask)
 
 #ifndef IS_KSH
 int
-sigismember(sigset_t *mask, int sig)
+sigismember(mask, sig)
+  sigset_t *mask;
+  int sig;
 {
   return ((*mask) & sigmask(sig));
 }
@@ -305,7 +315,8 @@ sigismember(sigset_t *mask, int sig)
 
 #ifndef IS_KSH
 int
-sigpending(sigset_t *set)
+sigpending(set)
+  sigset_t *set;
 {
   return 0;				/* faking it! */
 }
@@ -313,7 +324,9 @@ sigpending(sigset_t *set)
 
 
 int
-sigprocmask(int how, sigset_t *set, sigset_t *oset)
+sigprocmask(how, set, oset)
+  int how;
+  sigset_t *set, *oset;
 {
 #ifdef USE_SIGSET
   register int i;
@@ -377,7 +390,8 @@ sigprocmask(int how, sigset_t *set, sigset_t *oset)
 
 
 int
-sigsuspend(sigset_t *mask)
+sigsuspend(mask)
+  sigset_t *mask;
 {
 #ifdef USE_SIGMASK
   sigpause(*mask);
@@ -433,8 +447,9 @@ sigsuspend(sigset_t *mask)
  */
 
 #ifndef IS_KSH
-handler_t
-Signal(int sig, handler_t handler)
+handler_t Signal(sig, handler)
+  int sig;
+  handler_t handler;
 {
   struct sigaction act, oact;
 
@@ -453,8 +468,9 @@ Signal(int sig, handler_t handler)
  * ensure we avoid signal mayhem
  */
 
-handler_t
-signal(int sig, handler_t handler)
+handler_t signal(sig, handler)
+  int sig;
+  handler_t handler;
 {
   return (Signal(sig, handler));
 }
@@ -468,4 +484,3 @@ signal(int sig, handler_t handler)
  * comment-column:40
  * End:
  */
-

--- a/bin/ksh/sigact.h
+++ b/bin/ksh/sigact.h
@@ -123,4 +123,3 @@ int	sigsuspend	ARGS(( sigset_t *mask ));
 #endif
 #endif /* ! SA_NOCLDSTOP */
 #endif /* _SIGACT_H */
-

--- a/bin/ksh/sigact.h
+++ b/bin/ksh/sigact.h
@@ -123,3 +123,4 @@ int	sigsuspend	ARGS(( sigset_t *mask ));
 #endif
 #endif /* ! SA_NOCLDSTOP */
 #endif /* _SIGACT_H */
+

--- a/bin/ksh/syn.c
+++ b/bin/ksh/syn.c
@@ -67,7 +67,7 @@ static	int	symbol;		/* yylex value */
 	((reject) ? (symbol) : (REJECT, symbol = yylex(cf)))
 
 static void
-yyparse(void)
+yyparse()
 {
 	int c;
 
@@ -82,7 +82,8 @@ yyparse(void)
 }
 
 static struct op *
-pipeline(int cf)
+pipeline(cf)
+	int cf;
 {
 	register struct op *t, *p, *tl = NULL;
 
@@ -102,7 +103,7 @@ pipeline(int cf)
 }
 
 static struct op *
-andor(void)
+andor()
 {
 	register struct op *t, *p;
 	register int c;
@@ -120,7 +121,8 @@ andor(void)
 }
 
 static struct op *
-c_list(int multi)
+c_list(multi)
+	int multi;
 {
 	register struct op *t = NULL, *p, *tl = NULL;
 	register int c;
@@ -157,7 +159,8 @@ c_list(int multi)
 }
 
 static struct ioword *
-synio(int cf)
+synio(cf)
+	int cf;
 {
 	register struct ioword *iop;
 	int ishere;
@@ -181,14 +184,16 @@ synio(int cf)
 }
 
 static void
-musthave(int c, int cf)
+musthave(c, cf)
+	int c, cf;
 {
 	if ((token(cf)) != c)
 		syntaxerr((char *) 0);
 }
 
 static struct op *
-nested(int type, int smark, int emark)
+nested(type, smark, emark)
+	int type, smark, emark;
 {
 	register struct op *t;
 	struct nesting_state old_nesting;
@@ -201,7 +206,8 @@ nested(int type, int smark, int emark)
 }
 
 static struct op *
-get_command(int cf)
+get_command(cf)
+	int cf;
 {
 	register struct op *t;
 	register int c, iopn = 0, syniocf;
@@ -417,7 +423,7 @@ get_command(int cf)
 }
 
 static struct op *
-dogroup(void)
+dogroup()
 {
 	register int c;
 	register struct op *list;
@@ -440,7 +446,7 @@ dogroup(void)
 }
 
 static struct op *
-thenpart(void)
+thenpart()
 {
 	register struct op *t;
 
@@ -454,7 +460,7 @@ thenpart(void)
 }
 
 static struct op *
-elsepart(void)
+elsepart()
 {
 	register struct op *t;
 
@@ -477,7 +483,7 @@ elsepart(void)
 }
 
 static struct op *
-caselist(void)
+caselist()
 {
 	register struct op *t, *tl;
 	int c;
@@ -503,7 +509,8 @@ caselist(void)
 }
 
 static struct op *
-casepart(int endtok)
+casepart(endtok)
+	int endtok;
 {
 	register struct op *t;
 	register int c;
@@ -530,10 +537,10 @@ casepart(int endtok)
 	return (t);
 }
 
-
-/* ksh_func - function foo { ... } vs foo() { .. } */
 static struct op *
-function_body(char *name, int ksh_func)
+function_body(name, ksh_func)
+	char *name;
+	int ksh_func;	/* function foo { ... } vs foo() { .. } */
 {
 	char *sname, *p;
 	struct op *t;
@@ -592,7 +599,7 @@ function_body(char *name, int ksh_func)
 }
 
 static char **
-wordlist(void)
+wordlist()
 {
 	register int c;
 	XPtrV args;
@@ -622,7 +629,10 @@ wordlist(void)
  */
 
 static struct op *
-block(int type, struct op *t1, struct op *t2, char **wp)
+block(type, t1, t2, wp)
+	int type;
+	struct op *t1, *t2;
+	char **wp;
 {
 	register struct op *t;
 
@@ -677,7 +687,7 @@ const	struct tokeninfo {
 };
 
 void
-initkeywords(void)
+initkeywords()
 {
 	register struct tokeninfo const *tt;
 	register struct tbl *p;
@@ -694,7 +704,8 @@ initkeywords(void)
 }
 
 static void
-syntaxerr(const char *what)
+syntaxerr(what)
+	const char *what;
 {
 	char redir[6];	/* 2<<- is the longest redirection, I think */
 	const char *s;
@@ -746,7 +757,9 @@ syntaxerr(const char *what)
 }
 
 static void
-nesting_push(struct nesting_state *save, int tok)
+nesting_push(save, tok)
+	struct nesting_state *save;
+	int tok;
 {
 	*save = nesting;
 	nesting.start_token = tok;
@@ -754,13 +767,15 @@ nesting_push(struct nesting_state *save, int tok)
 }
 
 static void
-nesting_pop(struct nesting_state *saved)
+nesting_pop(saved)
+	struct nesting_state *saved;
 {
 	nesting = *saved;
 }
 
 static struct op *
-newtp(int type)
+newtp(type)
+	int type;
 {
 	register struct op *t;
 
@@ -775,7 +790,8 @@ newtp(int type)
 }
 
 struct op *
-compile(Source *s)
+compile(s)
+	Source *s;
 {
 	nesting.start_token = 0;
 	nesting.start_line = 0;
@@ -796,7 +812,8 @@ compile(Source *s)
  *	$
  */
 static int
-assign_command(char *s)
+assign_command(s)
+	char *s;
 {
 	char c = *s;
 
@@ -810,7 +827,8 @@ assign_command(char *s)
 
 /* Check if we are in the middle of reading an alias */
 static int
-inalias(struct source *s)
+inalias(s)
+	struct source *s;
 {
 	for (; s && s->type == SALIAS; s = s->next)
 		if (!(s->flags & SF_ALIASEND))
@@ -843,7 +861,9 @@ const char db_gthan[] = { CHAR, '>', EOS };
  * TM_UNOP and TM_BINOP, the returned value is a Test_op).
  */
 static int
-dbtestp_isa(Test_env *te, Test_meta meta)
+dbtestp_isa(te, meta)
+	Test_env *te;
+	Test_meta meta;
 {
 	int c = tpeek(ARRAYVAR | (meta == TM_BINOP ? 0 : CONTIN));
 	int uqword = 0;
@@ -891,7 +911,10 @@ dbtestp_isa(Test_env *te, Test_meta meta)
 }
 
 static const char *
-dbtestp_getopnd(Test_env *te, Test_op op, int do_eval)
+dbtestp_getopnd(te, op, do_eval)
+	Test_env *te;
+	Test_op op;
+	int do_eval;
 {
 	int c = tpeek(ARRAYVAR);
 
@@ -905,14 +928,21 @@ dbtestp_getopnd(Test_env *te, Test_op op, int do_eval)
 }
 
 static int
-dbtestp_eval(Test_env *te, Test_op op, const char *opnd1, const char *opnd2,
-			 int do_eval)
+dbtestp_eval(te, op, opnd1, opnd2, do_eval)
+	Test_env *te;
+	Test_op op;
+	const char *opnd1;
+	const char *opnd2;
+	int do_eval;
 {
 	return 1;
 }
 
 static void
-dbtestp_error(Test_env *te, int offset, const char *msg)
+dbtestp_error(te, offset, msg)
+	Test_env *te;
+	int offset;
+	const char *msg;
 {
 	te->flags |= TEF_ERROR;
 
@@ -926,4 +956,3 @@ dbtestp_error(Test_env *te, int offset, const char *msg)
 	syntaxerr(msg);
 }
 #endif /* KSH */
-

--- a/bin/ksh/syn.c
+++ b/bin/ksh/syn.c
@@ -67,7 +67,7 @@ static	int	symbol;		/* yylex value */
 	((reject) ? (symbol) : (REJECT, symbol = yylex(cf)))
 
 static void
-yyparse()
+yyparse(void)
 {
 	int c;
 
@@ -82,8 +82,7 @@ yyparse()
 }
 
 static struct op *
-pipeline(cf)
-	int cf;
+pipeline(int cf)
 {
 	register struct op *t, *p, *tl = NULL;
 
@@ -103,7 +102,7 @@ pipeline(cf)
 }
 
 static struct op *
-andor()
+andor(void)
 {
 	register struct op *t, *p;
 	register int c;
@@ -121,8 +120,7 @@ andor()
 }
 
 static struct op *
-c_list(multi)
-	int multi;
+c_list(int multi)
 {
 	register struct op *t = NULL, *p, *tl = NULL;
 	register int c;
@@ -159,8 +157,7 @@ c_list(multi)
 }
 
 static struct ioword *
-synio(cf)
-	int cf;
+synio(int cf)
 {
 	register struct ioword *iop;
 	int ishere;
@@ -184,16 +181,14 @@ synio(cf)
 }
 
 static void
-musthave(c, cf)
-	int c, cf;
+musthave(int c, int cf)
 {
 	if ((token(cf)) != c)
 		syntaxerr((char *) 0);
 }
 
 static struct op *
-nested(type, smark, emark)
-	int type, smark, emark;
+nested(int type, int smark, int emark)
 {
 	register struct op *t;
 	struct nesting_state old_nesting;
@@ -206,8 +201,7 @@ nested(type, smark, emark)
 }
 
 static struct op *
-get_command(cf)
-	int cf;
+get_command(int cf)
 {
 	register struct op *t;
 	register int c, iopn = 0, syniocf;
@@ -423,7 +417,7 @@ get_command(cf)
 }
 
 static struct op *
-dogroup()
+dogroup(void)
 {
 	register int c;
 	register struct op *list;
@@ -446,7 +440,7 @@ dogroup()
 }
 
 static struct op *
-thenpart()
+thenpart(void)
 {
 	register struct op *t;
 
@@ -460,7 +454,7 @@ thenpart()
 }
 
 static struct op *
-elsepart()
+elsepart(void)
 {
 	register struct op *t;
 
@@ -483,7 +477,7 @@ elsepart()
 }
 
 static struct op *
-caselist()
+caselist(void)
 {
 	register struct op *t, *tl;
 	int c;
@@ -509,8 +503,7 @@ caselist()
 }
 
 static struct op *
-casepart(endtok)
-	int endtok;
+casepart(int endtok)
 {
 	register struct op *t;
 	register int c;
@@ -537,10 +530,10 @@ casepart(endtok)
 	return (t);
 }
 
+
+/* ksh_func - function foo { ... } vs foo() { .. } */
 static struct op *
-function_body(name, ksh_func)
-	char *name;
-	int ksh_func;	/* function foo { ... } vs foo() { .. } */
+function_body(char *name, int ksh_func)
 {
 	char *sname, *p;
 	struct op *t;
@@ -599,7 +592,7 @@ function_body(name, ksh_func)
 }
 
 static char **
-wordlist()
+wordlist(void)
 {
 	register int c;
 	XPtrV args;
@@ -629,10 +622,7 @@ wordlist()
  */
 
 static struct op *
-block(type, t1, t2, wp)
-	int type;
-	struct op *t1, *t2;
-	char **wp;
+block(int type, struct op *t1, struct op *t2, char **wp)
 {
 	register struct op *t;
 
@@ -687,7 +677,7 @@ const	struct tokeninfo {
 };
 
 void
-initkeywords()
+initkeywords(void)
 {
 	register struct tokeninfo const *tt;
 	register struct tbl *p;
@@ -704,8 +694,7 @@ initkeywords()
 }
 
 static void
-syntaxerr(what)
-	const char *what;
+syntaxerr(const char *what)
 {
 	char redir[6];	/* 2<<- is the longest redirection, I think */
 	const char *s;
@@ -757,9 +746,7 @@ syntaxerr(what)
 }
 
 static void
-nesting_push(save, tok)
-	struct nesting_state *save;
-	int tok;
+nesting_push(struct nesting_state *save, int tok)
 {
 	*save = nesting;
 	nesting.start_token = tok;
@@ -767,15 +754,13 @@ nesting_push(save, tok)
 }
 
 static void
-nesting_pop(saved)
-	struct nesting_state *saved;
+nesting_pop(struct nesting_state *saved)
 {
 	nesting = *saved;
 }
 
 static struct op *
-newtp(type)
-	int type;
+newtp(int type)
 {
 	register struct op *t;
 
@@ -790,8 +775,7 @@ newtp(type)
 }
 
 struct op *
-compile(s)
-	Source *s;
+compile(Source *s)
 {
 	nesting.start_token = 0;
 	nesting.start_line = 0;
@@ -812,8 +796,7 @@ compile(s)
  *	$
  */
 static int
-assign_command(s)
-	char *s;
+assign_command(char *s)
 {
 	char c = *s;
 
@@ -827,8 +810,7 @@ assign_command(s)
 
 /* Check if we are in the middle of reading an alias */
 static int
-inalias(s)
-	struct source *s;
+inalias(struct source *s)
 {
 	for (; s && s->type == SALIAS; s = s->next)
 		if (!(s->flags & SF_ALIASEND))
@@ -861,9 +843,7 @@ const char db_gthan[] = { CHAR, '>', EOS };
  * TM_UNOP and TM_BINOP, the returned value is a Test_op).
  */
 static int
-dbtestp_isa(te, meta)
-	Test_env *te;
-	Test_meta meta;
+dbtestp_isa(Test_env *te, Test_meta meta)
 {
 	int c = tpeek(ARRAYVAR | (meta == TM_BINOP ? 0 : CONTIN));
 	int uqword = 0;
@@ -911,10 +891,7 @@ dbtestp_isa(te, meta)
 }
 
 static const char *
-dbtestp_getopnd(te, op, do_eval)
-	Test_env *te;
-	Test_op op;
-	int do_eval;
+dbtestp_getopnd(Test_env *te, Test_op op, int do_eval)
 {
 	int c = tpeek(ARRAYVAR);
 
@@ -928,21 +905,14 @@ dbtestp_getopnd(te, op, do_eval)
 }
 
 static int
-dbtestp_eval(te, op, opnd1, opnd2, do_eval)
-	Test_env *te;
-	Test_op op;
-	const char *opnd1;
-	const char *opnd2;
-	int do_eval;
+dbtestp_eval(Test_env *te, Test_op op, const char *opnd1, const char *opnd2,
+			 int do_eval)
 {
 	return 1;
 }
 
 static void
-dbtestp_error(te, offset, msg)
-	Test_env *te;
-	int offset;
-	const char *msg;
+dbtestp_error(Test_env *te, int offset, const char *msg)
 {
 	te->flags |= TEF_ERROR;
 
@@ -956,3 +926,4 @@ dbtestp_error(te, offset, msg)
 	syntaxerr(msg);
 }
 #endif /* KSH */
+

--- a/bin/ksh/table.c
+++ b/bin/ksh/table.c
@@ -19,7 +19,8 @@ static int      tnamecmp    ARGS((void *p1, void *p2));
 
 
 unsigned int
-hash(register const char *n)
+hash(n)
+	register const char * n;
 {
 	register unsigned int h = 0;
 
@@ -29,7 +30,10 @@ hash(register const char *n)
 }
 
 void
-tinit(register struct table *tp, register Area *ap, int tsize)
+tinit(tp, ap, tsize)
+	register struct table *tp;
+	register Area *ap;
+	int tsize;
 {
 	tp->areap = ap;
 	tp->tbls = NULL;
@@ -39,7 +43,9 @@ tinit(register struct table *tp, register Area *ap, int tsize)
 }
 
 static void
-texpand(register struct table *tp, int nsize)
+texpand(tp, nsize)
+	register struct table *tp;
+	int nsize;
 {
 	register int i;
 	register struct tbl *tblp, **p;
@@ -72,13 +78,11 @@ texpand(register struct table *tp, int nsize)
 	afree((void*)otblp, tp->areap);
 }
 
-/*
- * tp - table
- * n - name to enter
- * h - hash(n)
- */
 struct tbl *
-tsearch(register struct table *tp, register const char *n, unsigned int h)
+tsearch(tp, n, h)
+	register struct table *tp;	/* table */
+	register const char *n;		/* name to enter */
+	unsigned int h;			/* hash(n) */
 {
 	register struct tbl **pp, *p;
 
@@ -97,13 +101,11 @@ tsearch(register struct table *tp, register const char *n, unsigned int h)
 	return NULL;
 }
 
-/*
- * tp - table
- * n - name to enter
- * h - hash(n)
- */
 struct tbl *
-tenter(register struct table *tp, register const char *n, unsigned int h)
+tenter(tp, n, h)
+	register struct table *tp;	/* table */
+	register const char *n;		/* name to enter */
+	unsigned int h;			/* hash(n) */
 {
 	register struct tbl **pp, *p;
 	register int len;
@@ -142,20 +144,24 @@ tenter(register struct table *tp, register const char *n, unsigned int h)
 }
 
 void
-tdelete(register struct tbl *p)
+tdelete(p)
+	register struct tbl *p;
 {
 	p->flag = 0;
 }
 
 void
-twalk(struct tstate *ts, struct table *tp)
+twalk(ts, tp)
+	struct tstate *ts;
+	struct table *tp;
 {
 	ts->left = tp->size;
 	ts->next = tp->tbls;
 }
 
 struct tbl *
-tnext(struct tstate *ts)
+tnext(ts)
+	struct tstate *ts;
 {
 	while (--ts->left >= 0) {
 		struct tbl *p = *ts->next++;
@@ -166,13 +172,15 @@ tnext(struct tstate *ts)
 }
 
 static int
-tnamecmp(void *p1, void *p2)
+tnamecmp(p1, p2)
+	void *p1, *p2;
 {
 	return strcmp(((struct tbl *)p1)->name, ((struct tbl *)p2)->name);
 }
 
 struct tbl **
-tsort(register struct table *tp)
+tsort(tp)
+	register struct table *tp;
 {
 	register int i;
 	register struct tbl **p, **sp, **dp;
@@ -195,7 +203,8 @@ tsort(register struct table *tp)
 void tprintinfo ARGS((struct table *tp));
 
 void
-tprintinfo(struct table *tp)
+tprintinfo(tp)
+	struct table *tp;
 {
 	struct tbl *te;
 	char *n;
@@ -236,4 +245,3 @@ tprintinfo(struct table *tp)
 			(totncmp % nentries) * 100 / nentries);
 }
 #endif /* PERF_DEBUG */
-

--- a/bin/ksh/table.c
+++ b/bin/ksh/table.c
@@ -19,8 +19,7 @@ static int      tnamecmp    ARGS((void *p1, void *p2));
 
 
 unsigned int
-hash(n)
-	register const char * n;
+hash(register const char *n)
 {
 	register unsigned int h = 0;
 
@@ -30,10 +29,7 @@ hash(n)
 }
 
 void
-tinit(tp, ap, tsize)
-	register struct table *tp;
-	register Area *ap;
-	int tsize;
+tinit(register struct table *tp, register Area *ap, int tsize)
 {
 	tp->areap = ap;
 	tp->tbls = NULL;
@@ -43,9 +39,7 @@ tinit(tp, ap, tsize)
 }
 
 static void
-texpand(tp, nsize)
-	register struct table *tp;
-	int nsize;
+texpand(register struct table *tp, int nsize)
 {
 	register int i;
 	register struct tbl *tblp, **p;
@@ -78,11 +72,13 @@ texpand(tp, nsize)
 	afree((void*)otblp, tp->areap);
 }
 
+/*
+ * tp - table
+ * n - name to enter
+ * h - hash(n)
+ */
 struct tbl *
-tsearch(tp, n, h)
-	register struct table *tp;	/* table */
-	register const char *n;		/* name to enter */
-	unsigned int h;			/* hash(n) */
+tsearch(register struct table *tp, register const char *n, unsigned int h)
 {
 	register struct tbl **pp, *p;
 
@@ -101,11 +97,13 @@ tsearch(tp, n, h)
 	return NULL;
 }
 
+/*
+ * tp - table
+ * n - name to enter
+ * h - hash(n)
+ */
 struct tbl *
-tenter(tp, n, h)
-	register struct table *tp;	/* table */
-	register const char *n;		/* name to enter */
-	unsigned int h;			/* hash(n) */
+tenter(register struct table *tp, register const char *n, unsigned int h)
 {
 	register struct tbl **pp, *p;
 	register int len;
@@ -144,24 +142,20 @@ tenter(tp, n, h)
 }
 
 void
-tdelete(p)
-	register struct tbl *p;
+tdelete(register struct tbl *p)
 {
 	p->flag = 0;
 }
 
 void
-twalk(ts, tp)
-	struct tstate *ts;
-	struct table *tp;
+twalk(struct tstate *ts, struct table *tp)
 {
 	ts->left = tp->size;
 	ts->next = tp->tbls;
 }
 
 struct tbl *
-tnext(ts)
-	struct tstate *ts;
+tnext(struct tstate *ts)
 {
 	while (--ts->left >= 0) {
 		struct tbl *p = *ts->next++;
@@ -172,15 +166,13 @@ tnext(ts)
 }
 
 static int
-tnamecmp(p1, p2)
-	void *p1, *p2;
+tnamecmp(void *p1, void *p2)
 {
 	return strcmp(((struct tbl *)p1)->name, ((struct tbl *)p2)->name);
 }
 
 struct tbl **
-tsort(tp)
-	register struct table *tp;
+tsort(register struct table *tp)
 {
 	register int i;
 	register struct tbl **p, **sp, **dp;
@@ -203,8 +195,7 @@ tsort(tp)
 void tprintinfo ARGS((struct table *tp));
 
 void
-tprintinfo(tp)
-	struct table *tp;
+tprintinfo(struct table *tp)
 {
 	struct tbl *te;
 	char *n;
@@ -245,3 +236,4 @@ tprintinfo(tp)
 			(totncmp % nentries) * 100 / nentries);
 }
 #endif /* PERF_DEBUG */
+

--- a/bin/ksh/table.h
+++ b/bin/ksh/table.h
@@ -179,3 +179,4 @@ EXTERN char *tmpdir;		/* TMPDIR value */
 EXTERN const char *prompt;
 EXTERN int cur_prompt;		/* PS1 or PS2 */
 EXTERN int current_lineno;	/* LINENO value */
+

--- a/bin/ksh/table.h
+++ b/bin/ksh/table.h
@@ -179,4 +179,3 @@ EXTERN char *tmpdir;		/* TMPDIR value */
 EXTERN const char *prompt;
 EXTERN int cur_prompt;		/* PS1 or PS2 */
 EXTERN int current_lineno;	/* LINENO value */
-

--- a/bin/ksh/trap.c
+++ b/bin/ksh/trap.c
@@ -28,7 +28,7 @@ Trap sigtraps[SIGNALS+1] = {
 static struct sigaction Sigact_ign, Sigact_trap;
 
 void
-inittraps()
+inittraps(void)
 {
 #ifdef HAVE_SYS_SIGLIST
 # ifndef SYS_SIGLIST_DECLARED
@@ -65,7 +65,7 @@ inittraps()
 static RETSIGTYPE alarm_catcher ARGS((int sig));
 
 void
-alarm_init()
+alarm_init(void)
 {
 	sigtraps[SIGALRM].flags |= TF_SHELL_USES;
 	setsig(&sigtraps[SIGALRM], alarm_catcher,
@@ -73,8 +73,7 @@ alarm_init()
 }
 
 static RETSIGTYPE
-alarm_catcher(sig)
-	int sig;
+alarm_catcher(int sig)
 {
 	int errno_ = errno;
 
@@ -93,9 +92,7 @@ alarm_catcher(sig)
 #endif /* KSH */
 
 Trap *
-gettrap(name, igncase)
-	const char *name;
-	int igncase;
+gettrap(const char *name, int igncase)
 {
 	int i;
 	register Trap *p;
@@ -129,8 +126,7 @@ gettrap(name, igncase)
  * trap signal handler
  */
 RETSIGTYPE
-trapsig(i)
-	int i;
+trapsig(int i)
 {
 	Trap *p = &sigtraps[i];
 	int errno_ = errno;
@@ -156,7 +152,7 @@ trapsig(i)
  * work if user has trapped SIGINT.
  */
 void
-intrcheck()
+intrcheck(void)
 {
 	if (intrsig)
 		runtraps(TF_DFL_INTR|TF_FATAL);
@@ -166,7 +162,7 @@ intrcheck()
  * termination has been received.
  */
 int
-fatal_trap_check()
+fatal_trap_check(void)
 {
 	int i;
 	Trap *p;
@@ -184,7 +180,7 @@ fatal_trap_check()
  * is set.
  */
 int
-trap_pending()
+trap_pending(void)
 {
 	int i;
 	Trap *p;
@@ -202,8 +198,7 @@ trap_pending()
  * can interrupt commands.
  */
 void
-runtraps(flag)
-	int flag;
+runtraps(int flag)
 {
 	int i;
 	register Trap *p;
@@ -232,8 +227,7 @@ runtraps(flag)
 }
 
 void
-runtrap(p)
-	Trap *p;
+runtrap(Trap *p)
 {
 	int	i = p->signal;
 	char	*trapstr = p->trap;
@@ -279,7 +273,7 @@ runtrap(p)
 
 /* clear pending traps and reset user's trap handlers; used after fork(2) */
 void
-cleartraps()
+cleartraps(void)
 {
 	int i;
 	Trap *p;
@@ -296,7 +290,7 @@ cleartraps()
 
 /* restore signals just before an exec(2) */
 void
-restoresigs()
+restoresigs(void)
 {
 	int i;
 	Trap *p;
@@ -308,9 +302,7 @@ restoresigs()
 }
 
 void
-settrap(p, s)
-	Trap *p;
-	char *s;
+settrap(Trap *p, char *s)
 {
 	handler_t f;
 
@@ -349,7 +341,7 @@ settrap(p, s)
  * kill shell (unless user catches it and exits)
  */
 int
-block_pipe()
+block_pipe(void)
 {
 	int restore_dfl = 0;
 	Trap *p = &sigtraps[SIGPIPE];
@@ -367,8 +359,7 @@ block_pipe()
 
 /* Called by c_print() to undo whatever block_pipe() did */
 void
-restore_pipe(restore_dfl)
-	int restore_dfl;
+restore_pipe(int restore_dfl)
 {
 	if (restore_dfl)
 		setsig(&sigtraps[SIGPIPE], SIG_DFL, SS_RESTORE_CURR);
@@ -379,10 +370,7 @@ restore_pipe(restore_dfl)
  * FTALKING.
  */
 int
-setsig(p, f, flags)
-	Trap *p;
-	handler_t f;
-	int flags;
+setsig(Trap *p, handler_t f, int flags)
 {
 	struct sigaction sigact;
 
@@ -433,9 +421,7 @@ setsig(p, f, flags)
 
 /* control what signal is set to before an exec() */
 void
-setexecsig(p, restore)
-	Trap *p;
-	int restore;
+setexecsig(Trap *p, int restore)
 {
 	/* XXX debugging */
 	if (!(p->flags & (TF_ORIG_IGN|TF_ORIG_DFL)))
@@ -458,3 +444,4 @@ setexecsig(p, restore)
 		break;
 	}
 }
+

--- a/bin/ksh/trap.c
+++ b/bin/ksh/trap.c
@@ -28,7 +28,7 @@ Trap sigtraps[SIGNALS+1] = {
 static struct sigaction Sigact_ign, Sigact_trap;
 
 void
-inittraps(void)
+inittraps()
 {
 #ifdef HAVE_SYS_SIGLIST
 # ifndef SYS_SIGLIST_DECLARED
@@ -65,7 +65,7 @@ inittraps(void)
 static RETSIGTYPE alarm_catcher ARGS((int sig));
 
 void
-alarm_init(void)
+alarm_init()
 {
 	sigtraps[SIGALRM].flags |= TF_SHELL_USES;
 	setsig(&sigtraps[SIGALRM], alarm_catcher,
@@ -73,7 +73,8 @@ alarm_init(void)
 }
 
 static RETSIGTYPE
-alarm_catcher(int sig)
+alarm_catcher(sig)
+	int sig;
 {
 	int errno_ = errno;
 
@@ -92,7 +93,9 @@ alarm_catcher(int sig)
 #endif /* KSH */
 
 Trap *
-gettrap(const char *name, int igncase)
+gettrap(name, igncase)
+	const char *name;
+	int igncase;
 {
 	int i;
 	register Trap *p;
@@ -126,7 +129,8 @@ gettrap(const char *name, int igncase)
  * trap signal handler
  */
 RETSIGTYPE
-trapsig(int i)
+trapsig(i)
+	int i;
 {
 	Trap *p = &sigtraps[i];
 	int errno_ = errno;
@@ -152,7 +156,7 @@ trapsig(int i)
  * work if user has trapped SIGINT.
  */
 void
-intrcheck(void)
+intrcheck()
 {
 	if (intrsig)
 		runtraps(TF_DFL_INTR|TF_FATAL);
@@ -162,7 +166,7 @@ intrcheck(void)
  * termination has been received.
  */
 int
-fatal_trap_check(void)
+fatal_trap_check()
 {
 	int i;
 	Trap *p;
@@ -180,7 +184,7 @@ fatal_trap_check(void)
  * is set.
  */
 int
-trap_pending(void)
+trap_pending()
 {
 	int i;
 	Trap *p;
@@ -198,7 +202,8 @@ trap_pending(void)
  * can interrupt commands.
  */
 void
-runtraps(int flag)
+runtraps(flag)
+	int flag;
 {
 	int i;
 	register Trap *p;
@@ -227,7 +232,8 @@ runtraps(int flag)
 }
 
 void
-runtrap(Trap *p)
+runtrap(p)
+	Trap *p;
 {
 	int	i = p->signal;
 	char	*trapstr = p->trap;
@@ -273,7 +279,7 @@ runtrap(Trap *p)
 
 /* clear pending traps and reset user's trap handlers; used after fork(2) */
 void
-cleartraps(void)
+cleartraps()
 {
 	int i;
 	Trap *p;
@@ -290,7 +296,7 @@ cleartraps(void)
 
 /* restore signals just before an exec(2) */
 void
-restoresigs(void)
+restoresigs()
 {
 	int i;
 	Trap *p;
@@ -302,7 +308,9 @@ restoresigs(void)
 }
 
 void
-settrap(Trap *p, char *s)
+settrap(p, s)
+	Trap *p;
+	char *s;
 {
 	handler_t f;
 
@@ -341,7 +349,7 @@ settrap(Trap *p, char *s)
  * kill shell (unless user catches it and exits)
  */
 int
-block_pipe(void)
+block_pipe()
 {
 	int restore_dfl = 0;
 	Trap *p = &sigtraps[SIGPIPE];
@@ -359,7 +367,8 @@ block_pipe(void)
 
 /* Called by c_print() to undo whatever block_pipe() did */
 void
-restore_pipe(int restore_dfl)
+restore_pipe(restore_dfl)
+	int restore_dfl;
 {
 	if (restore_dfl)
 		setsig(&sigtraps[SIGPIPE], SIG_DFL, SS_RESTORE_CURR);
@@ -370,7 +379,10 @@ restore_pipe(int restore_dfl)
  * FTALKING.
  */
 int
-setsig(Trap *p, handler_t f, int flags)
+setsig(p, f, flags)
+	Trap *p;
+	handler_t f;
+	int flags;
 {
 	struct sigaction sigact;
 
@@ -421,7 +433,9 @@ setsig(Trap *p, handler_t f, int flags)
 
 /* control what signal is set to before an exec() */
 void
-setexecsig(Trap *p, int restore)
+setexecsig(p, restore)
+	Trap *p;
+	int restore;
 {
 	/* XXX debugging */
 	if (!(p->flags & (TF_ORIG_IGN|TF_ORIG_DFL)))
@@ -444,4 +458,3 @@ setexecsig(Trap *p, int restore)
 		break;
 	}
 }
-

--- a/bin/ksh/tree.c
+++ b/bin/ksh/tree.c
@@ -28,10 +28,7 @@ static void     iofree ARGS((struct ioword **iow, Area *ap));
  */
 
 static void
-ptree(t, indent, shf)
-	register struct op *t;
-	int indent;
-	register struct shf *shf;
+ptree(register struct op *t, int indent, register struct shf *shf)
 {
 	register char **w;
 	struct ioword **ioact;
@@ -215,10 +212,7 @@ ptree(t, indent, shf)
 }
 
 static void
-pioact(shf, indent, iop)
-	register struct shf *shf;
-	int indent;
-	register struct ioword *iop;
+pioact(register struct shf *shf, int indent, register struct ioword *iop)
 {
 	int flag = iop->flag;
 	int type = flag & IOTYPE;
@@ -276,9 +270,7 @@ pioact(shf, indent, iop)
  */
 
 static void
-tputC(c, shf)
-	register int c;
-	register struct shf *shf;
+tputC(register int c, register struct shf *shf)
 {
 	if ((c&0x60) == 0) {		/* C0|C1 */
 		tputc((c&0x80) ? '$' : '^', shf);
@@ -291,9 +283,7 @@ tputC(c, shf)
 }
 
 static void
-tputS(wp, shf)
-	register char *wp;
-	register struct shf *shf;
+tputS(register char *wp, register struct shf *shf)
 {
 	register int c, quoted=0;
 
@@ -375,15 +365,7 @@ tputS(wp, shf)
  */
 /* VARARGS */
 int
-#ifdef HAVE_PROTOTYPES
 fptreef(struct shf *shf, int indent, const char *fmt, ...)
-#else
-fptreef(shf, indent, fmt, va_alist)
-  struct shf *shf;
-  int indent;
-  const char *fmt;
-  va_dcl
-#endif
 {
   va_list	va;
 
@@ -396,15 +378,7 @@ fptreef(shf, indent, fmt, va_alist)
 
 /* VARARGS */
 char *
-#ifdef HAVE_PROTOTYPES
 snptreef(char *s, int n, const char *fmt, ...)
-#else
-snptreef(s, n, fmt, va_alist)
-  char *s;
-  int n;
-  const char *fmt;
-  va_dcl
-#endif
 {
   va_list va;
   struct shf shf;
@@ -419,11 +393,8 @@ snptreef(s, n, fmt, va_alist)
 }
 
 static void
-vfptreef(shf, indent, fmt, va)
-	register struct shf *shf;
-	int indent;
-	const char *fmt;
-	register va_list va;
+vfptreef(register struct shf *shf, int indent, const char *fmt,
+		register va_list va)
 {
 	register int c;
 
@@ -491,9 +462,7 @@ vfptreef(shf, indent, fmt, va)
  */
 
 struct op *
-tcopy(t, ap)
-	register struct op *t;
-	Area *ap;
+tcopy(register struct op *t, Area *ap)
 {
 	register struct op *r;
 	register char **tw, **rw;
@@ -542,9 +511,7 @@ tcopy(t, ap)
 }
 
 char *
-wdcopy(wp, ap)
-	const char *wp;
-	Area *ap;
+wdcopy(const char *wp, Area *ap)
 {
 	size_t len = wdscan(wp, EOS) - wp;
 	return memcpy(alloc(len, ap), wp, len);
@@ -552,9 +519,7 @@ wdcopy(wp, ap)
 
 /* return the position of prefix c in wp plus 1 */
 char *
-wdscan(wp, c)
-	register const char *wp;
-	register int c;
+wdscan(register const char *wp, register int c)
 {
 	register int nest = 0;
 
@@ -610,8 +575,7 @@ wdscan(wp, c)
  * (string is allocated from ATEMP)
  */
 char *
-wdstrip(wp)
-	const char *wp;
+wdstrip(const char *wp)
 {
 	struct shf shf;
 	int c;
@@ -678,9 +642,7 @@ wdstrip(wp)
 }
 
 static	struct ioword **
-iocopy(iow, ap)
-	register struct ioword **iow;
-	Area *ap;
+iocopy(register struct ioword **iow, Area *ap)
 {
 	register struct ioword **ior;
 	register int i;
@@ -713,9 +675,7 @@ iocopy(iow, ap)
  */
 
 void
-tfree(t, ap)
-	register struct op *t;
-	Area *ap;
+tfree(register struct op *t, Area *ap)
 {
 	register char **w;
 
@@ -747,9 +707,7 @@ tfree(t, ap)
 }
 
 static	void
-iofree(iow, ap)
-	struct ioword **iow;
-	Area *ap;
+iofree(struct ioword **iow, Area *ap)
 {
 	register struct ioword **iop;
 	register struct ioword *p;
@@ -764,3 +722,4 @@ iofree(iow, ap)
 		afree((void*)p, ap);
 	}
 }
+

--- a/bin/ksh/tree.c
+++ b/bin/ksh/tree.c
@@ -28,7 +28,10 @@ static void     iofree ARGS((struct ioword **iow, Area *ap));
  */
 
 static void
-ptree(register struct op *t, int indent, register struct shf *shf)
+ptree(t, indent, shf)
+	register struct op *t;
+	int indent;
+	register struct shf *shf;
 {
 	register char **w;
 	struct ioword **ioact;
@@ -212,7 +215,10 @@ ptree(register struct op *t, int indent, register struct shf *shf)
 }
 
 static void
-pioact(register struct shf *shf, int indent, register struct ioword *iop)
+pioact(shf, indent, iop)
+	register struct shf *shf;
+	int indent;
+	register struct ioword *iop;
 {
 	int flag = iop->flag;
 	int type = flag & IOTYPE;
@@ -270,7 +276,9 @@ pioact(register struct shf *shf, int indent, register struct ioword *iop)
  */
 
 static void
-tputC(register int c, register struct shf *shf)
+tputC(c, shf)
+	register int c;
+	register struct shf *shf;
 {
 	if ((c&0x60) == 0) {		/* C0|C1 */
 		tputc((c&0x80) ? '$' : '^', shf);
@@ -283,7 +291,9 @@ tputC(register int c, register struct shf *shf)
 }
 
 static void
-tputS(register char *wp, register struct shf *shf)
+tputS(wp, shf)
+	register char *wp;
+	register struct shf *shf;
 {
 	register int c, quoted=0;
 
@@ -365,7 +375,15 @@ tputS(register char *wp, register struct shf *shf)
  */
 /* VARARGS */
 int
+#ifdef HAVE_PROTOTYPES
 fptreef(struct shf *shf, int indent, const char *fmt, ...)
+#else
+fptreef(shf, indent, fmt, va_alist)
+  struct shf *shf;
+  int indent;
+  const char *fmt;
+  va_dcl
+#endif
 {
   va_list	va;
 
@@ -378,7 +396,15 @@ fptreef(struct shf *shf, int indent, const char *fmt, ...)
 
 /* VARARGS */
 char *
+#ifdef HAVE_PROTOTYPES
 snptreef(char *s, int n, const char *fmt, ...)
+#else
+snptreef(s, n, fmt, va_alist)
+  char *s;
+  int n;
+  const char *fmt;
+  va_dcl
+#endif
 {
   va_list va;
   struct shf shf;
@@ -393,8 +419,11 @@ snptreef(char *s, int n, const char *fmt, ...)
 }
 
 static void
-vfptreef(register struct shf *shf, int indent, const char *fmt,
-		register va_list va)
+vfptreef(shf, indent, fmt, va)
+	register struct shf *shf;
+	int indent;
+	const char *fmt;
+	register va_list va;
 {
 	register int c;
 
@@ -462,7 +491,9 @@ vfptreef(register struct shf *shf, int indent, const char *fmt,
  */
 
 struct op *
-tcopy(register struct op *t, Area *ap)
+tcopy(t, ap)
+	register struct op *t;
+	Area *ap;
 {
 	register struct op *r;
 	register char **tw, **rw;
@@ -511,7 +542,9 @@ tcopy(register struct op *t, Area *ap)
 }
 
 char *
-wdcopy(const char *wp, Area *ap)
+wdcopy(wp, ap)
+	const char *wp;
+	Area *ap;
 {
 	size_t len = wdscan(wp, EOS) - wp;
 	return memcpy(alloc(len, ap), wp, len);
@@ -519,7 +552,9 @@ wdcopy(const char *wp, Area *ap)
 
 /* return the position of prefix c in wp plus 1 */
 char *
-wdscan(register const char *wp, register int c)
+wdscan(wp, c)
+	register const char *wp;
+	register int c;
 {
 	register int nest = 0;
 
@@ -575,7 +610,8 @@ wdscan(register const char *wp, register int c)
  * (string is allocated from ATEMP)
  */
 char *
-wdstrip(const char *wp)
+wdstrip(wp)
+	const char *wp;
 {
 	struct shf shf;
 	int c;
@@ -642,7 +678,9 @@ wdstrip(const char *wp)
 }
 
 static	struct ioword **
-iocopy(register struct ioword **iow, Area *ap)
+iocopy(iow, ap)
+	register struct ioword **iow;
+	Area *ap;
 {
 	register struct ioword **ior;
 	register int i;
@@ -675,7 +713,9 @@ iocopy(register struct ioword **iow, Area *ap)
  */
 
 void
-tfree(register struct op *t, Area *ap)
+tfree(t, ap)
+	register struct op *t;
+	Area *ap;
 {
 	register char **w;
 
@@ -707,7 +747,9 @@ tfree(register struct op *t, Area *ap)
 }
 
 static	void
-iofree(struct ioword **iow, Area *ap)
+iofree(iow, ap)
+	struct ioword **iow;
+	Area *ap;
 {
 	register struct ioword **iop;
 	register struct ioword *p;
@@ -722,4 +764,3 @@ iofree(struct ioword **iow, Area *ap)
 		afree((void*)p, ap);
 	}
 }
-

--- a/bin/ksh/tree.h
+++ b/bin/ksh/tree.h
@@ -140,4 +140,3 @@ struct ioword {
 #define DB_AND	3		/* && -> -a conversion */
 #define DB_BE	4		/* an inserted -BE */
 #define DB_PAT	5		/* a pattern argument */
-

--- a/bin/ksh/tree.h
+++ b/bin/ksh/tree.h
@@ -140,3 +140,4 @@ struct ioword {
 #define DB_AND	3		/* && -> -a conversion */
 #define DB_BE	4		/* an inserted -BE */
 #define DB_PAT	5		/* a pattern argument */
+

--- a/bin/ksh/tty.c
+++ b/bin/ksh/tty.c
@@ -14,7 +14,9 @@ __RCSID("$NetBSD: tty.c,v 1.4 2003/06/23 11:39:06 agc Exp $");
 #undef EXTERN
 
 int
-get_tty(int fd, TTY_state *ts)
+get_tty(fd, ts)
+	int fd;
+	TTY_state *ts;
 {
 	int ret;
 
@@ -42,7 +44,10 @@ get_tty(int fd, TTY_state *ts)
 }
 
 int
-set_tty(int fd, TTY_state *ts, int flags)
+set_tty(fd, ts, flags)
+	int fd;
+	TTY_state *ts;
+	int flags;
 {
 	int ret = 0;
 
@@ -101,7 +106,8 @@ set_tty(int fd, TTY_state *ts, int flags)
  * foreground job completion and for setting up tty process group.
  */
 void
-tty_init(int init_ttystate)
+tty_init(init_ttystate)
+	int init_ttystate;
 {
 	int	do_close = 1;
 	int	tfd;
@@ -172,11 +178,10 @@ tty_init(int init_ttystate)
 }
 
 void
-tty_close(void)
+tty_close()
 {
 	if (tty_fd >= 0) {
 		close(tty_fd);
 		tty_fd = -1;
 	}
 }
-

--- a/bin/ksh/tty.c
+++ b/bin/ksh/tty.c
@@ -14,9 +14,7 @@ __RCSID("$NetBSD: tty.c,v 1.4 2003/06/23 11:39:06 agc Exp $");
 #undef EXTERN
 
 int
-get_tty(fd, ts)
-	int fd;
-	TTY_state *ts;
+get_tty(int fd, TTY_state *ts)
 {
 	int ret;
 
@@ -44,10 +42,7 @@ get_tty(fd, ts)
 }
 
 int
-set_tty(fd, ts, flags)
-	int fd;
-	TTY_state *ts;
-	int flags;
+set_tty(int fd, TTY_state *ts, int flags)
 {
 	int ret = 0;
 
@@ -106,8 +101,7 @@ set_tty(fd, ts, flags)
  * foreground job completion and for setting up tty process group.
  */
 void
-tty_init(init_ttystate)
-	int init_ttystate;
+tty_init(int init_ttystate)
 {
 	int	do_close = 1;
 	int	tfd;
@@ -178,10 +172,11 @@ tty_init(init_ttystate)
 }
 
 void
-tty_close()
+tty_close(void)
 {
 	if (tty_fd >= 0) {
 		close(tty_fd);
 		tty_fd = -1;
 	}
 }
+

--- a/bin/ksh/tty.h
+++ b/bin/ksh/tty.h
@@ -108,3 +108,4 @@ extern void	tty_close ARGS((void));
 # undef EXTERN
 #endif
 #undef I__
+

--- a/bin/ksh/tty.h
+++ b/bin/ksh/tty.h
@@ -108,4 +108,3 @@ extern void	tty_close ARGS((void));
 # undef EXTERN
 #endif
 #undef I__
-

--- a/bin/ksh/var.c
+++ b/bin/ksh/var.c
@@ -38,7 +38,7 @@ static struct tbl *arraysearch  ARGS((struct tbl *, int));
  * assume caller has allocated and set up e->loc
  */
 void
-newblock()
+newblock(void)
 {
 	register struct block *l;
 	static char *const empty[] = {null};
@@ -64,7 +64,7 @@ newblock()
  * pop a block handling special variables
  */
 void
-popblock()
+popblock(void)
 {
 	register struct block *l = e->loc;
 	register struct tbl *vp, **vpp = l->vars.tbls, *vq;
@@ -87,7 +87,7 @@ popblock()
 
 /* called by main() to initialize variable data structures */
 void
-initvar()
+initvar(void)
 {
 	static const struct {
 		const char *name;
@@ -136,10 +136,7 @@ initvar()
 const char *array_index_calc(const char *n, bool_t *arrayp, int *valp);
 
 const char *
-array_index_calc(n, arrayp, valp)
-	const char *n;
-	bool_t *arrayp;
-	int *valp;
+array_index_calc(const char *n, bool_t *arrayp, int *valp)
 {
 	const char *p;
 	int len;
@@ -169,8 +166,7 @@ array_index_calc(n, arrayp, valp)
  * Search for variable, if not found create globally.
  */
 struct tbl *
-global(n)
-	register const char *n;
+global(register const char *n)
 {
 	register struct block *l = e->loc;
 	register struct tbl *vp;
@@ -252,9 +248,7 @@ global(n)
  * Search for local variable, if not found create locally.
  */
 struct tbl *
-local(n, copy)
-	register const char *n;
-	bool_t copy;
+local(register const char *n, bool_t copy)
 {
 	register struct block *l = e->loc;
 	register struct tbl *vp;
@@ -298,8 +292,7 @@ local(n, copy)
 
 /* get variable string value */
 char *
-str_val(vp)
-	register struct tbl *vp;
+str_val(register struct tbl *vp)
 {
 	char *s;
 
@@ -351,8 +344,7 @@ str_val(vp)
 
 /* get variable integer value, with error checking */
 long
-intval(vp)
-	register struct tbl *vp;
+intval(register struct tbl *vp)
 {
 	long num;
 	int base;
@@ -366,10 +358,7 @@ intval(vp)
 
 /* set variable to string value */
 int
-setstr(vq, s, error_ok)
-	register struct tbl *vq;
-	const char *s;
-	int error_ok;
+setstr(register struct tbl *vq, const char *s, int error_ok)
 {
 	char *fs = NULL;
 	int no_ro_check = error_ok & 0x4;
@@ -413,9 +402,7 @@ setstr(vq, s, error_ok)
 
 /* set variable to integer */
 void
-setint(vq, n)
-	register struct tbl *vq;
-	long n;
+setint(register struct tbl *vq, long n)
 {
 	if (!(vq->flag&INTEGER)) {
 		register struct tbl *vp = &vtemp;
@@ -433,9 +420,7 @@ setint(vq, n)
 }
 
 int
-getint(vp, nump)
-	struct tbl *vp;
-	long *nump;
+getint(struct tbl *vp, long *nump)
 {
 	register char *s;
 	register int c;
@@ -499,8 +484,7 @@ getint(vp, nump)
  * (vq and vp may be the same)
  */
 struct tbl *
-setint_v(vq, vp)
-	register struct tbl *vq, *vp;
+setint_v(register struct tbl *vq, register struct tbl *vp)
 {
 	int base;
 	long num;
@@ -521,9 +505,7 @@ setint_v(vq, vp)
 }
 
 static char *
-formatstr(vp, s)
-	struct tbl *vp;
-	const char *s;
+formatstr(struct tbl *vp, const char *s)
 {
 	int olen, nlen;
 	char *p, *q;
@@ -585,9 +567,7 @@ formatstr(vp, s)
  * make vp->val.s be "name=value" for quick exporting.
  */
 static void
-export(vp, val)
-	register struct tbl *vp;
-	const char *val;
+export(register struct tbl *vp, const char *val)
 {
 	register char *xp;
 	char *op = (vp->flag&ALLOC) ? vp->val.s : NULL;
@@ -611,10 +591,7 @@ export(vp, val)
  * LCASEV, UCASEV_AL), and optionally set its value if an assignment.
  */
 struct tbl *
-typeset(var, set, clr, field, base)
-	register const char *var;
-	Tflag clr, set;
-	int field, base;
+typeset(register const char *var, Tflag set, Tflag clr, int field, int base)
 {
 	register struct tbl *vp;
 	struct tbl *vpbase, *t;
@@ -765,9 +742,7 @@ typeset(var, set, clr, field, base)
  * the name lookup (eg, x[2]).
  */
 void
-unset(vp, array_ref)
-	register struct tbl *vp;
-	int array_ref;
+unset(register struct tbl *vp, int array_ref)
 {
 	if (vp->flag & ALLOC)
 		afree((void*)vp->val.s, vp->areap);
@@ -795,9 +770,7 @@ unset(vp, array_ref)
  * null if whole string is legal).
  */
 char *
-skip_varname(s, aok)
-	const char *s;
-	int aok;
+skip_varname(const char *s, int aok)
 {
 	int alen;
 
@@ -810,11 +783,11 @@ skip_varname(s, aok)
 	return (char *) __UNCONST(s);
 }
 
-/* Return a pointer to the first character past any legal variable name.  */
+/* Return a pointer to the first character past any legal variable name.
+ * aok - skip array de-reference?
+ */
 char *
-skip_wdvarname(s, aok)
-	const char *s;
-	int aok;	/* skip array de-reference? */
+skip_wdvarname(const char *s, int aok)
 {
 	if (s[0] == CHAR && letter(s[1])) {
 		do
@@ -845,9 +818,7 @@ skip_wdvarname(s, aok)
 
 /* Check if coded string s is a variable name */
 int
-is_wdvarname(s, aok)
-	const char *s;
-	int aok;
+is_wdvarname(const char *s, int aok)
 {
 	char *p = skip_wdvarname(s, aok);
 
@@ -856,8 +827,7 @@ is_wdvarname(s, aok)
 
 /* Check if coded string s is a variable assignment */
 int
-is_wdvarassign(s)
-	const char *s;
+is_wdvarassign(const char *s)
 {
 	char *p = skip_wdvarname(s, TRUE);
 
@@ -868,7 +838,7 @@ is_wdvarassign(s)
  * Make the exported environment from the exported names in the dictionary.
  */
 char **
-makenv()
+makenv(void)
 {
 	struct block *l = e->loc;
 	XPtrV env;
@@ -910,7 +880,7 @@ makenv()
  * if the parent doesn't use $RANDOM.
  */
 void
-change_random()
+change_random(void)
 {
     rand();
 }
@@ -921,8 +891,7 @@ change_random()
 
 /* Test if name is a special parameter */
 static int
-special(name)
-	register const char * name;
+special(register const char *name)
 {
 	register struct tbl *tp;
 
@@ -932,8 +901,7 @@ special(name)
 
 /* Make a variable non-special */
 static void
-unspecial(name)
-	register const char * name;
+unspecial(register const char *name)
 {
 	register struct tbl *tp;
 
@@ -948,8 +916,7 @@ static	time_t	seconds;		/* time SECONDS last set */
 static	int	user_lineno;		/* what user set $LINENO to */
 
 static void
-getspec(vp)
-	register struct tbl *vp;
+getspec(register struct tbl *vp)
 {
 	switch (special(vp->name)) {
 #ifdef KSH
@@ -990,8 +957,7 @@ getspec(vp)
 }
 
 static void
-setspec(vp)
-	register struct tbl *vp;
+setspec(register struct tbl *vp)
 {
 	char *s;
 
@@ -1091,8 +1057,7 @@ setspec(vp)
 }
 
 static void
-unsetspec(vp)
-	register struct tbl *vp;
+unsetspec(register struct tbl *vp)
 {
 	switch (special(vp->name)) {
 	  case V_PATH:
@@ -1150,9 +1115,7 @@ unsetspec(vp)
  * vp, indexed by val.
  */
 static struct tbl *
-arraysearch(vp, val)
-	struct tbl *vp;
-	int val;
+arraysearch(struct tbl *vp, int val)
 {
 	struct tbl *prev, *curr, *new;
 	size_t namelen = strlen(vp->name) + 1;
@@ -1196,8 +1159,7 @@ arraysearch(vp, val)
  * bracket.
  */
 int
-array_ref_len(cp)
-	const char *cp;
+array_ref_len(const char *cp)
 {
 	const char *s = cp;
 	int c;
@@ -1215,8 +1177,7 @@ array_ref_len(cp)
  * Make a copy of the base of an array name
  */
 char *
-arrayname(str)
-	const char *str;
+arrayname(const char *str)
 {
 	const char *p;
 
@@ -1230,10 +1191,7 @@ arrayname(str)
 /* Set (or overwrite, if !reset) the array variable var to the values in vals.
  */
 void
-set_array(var, reset, vals)
-	const char *var;
-	int reset;
-	char **vals;
+set_array(const char *var, int reset, char **vals)
 {
 	struct tbl *vp, *vq;
 	int i;
@@ -1258,3 +1216,4 @@ set_array(var, reset, vals)
 		setstr(vq, vals[i], KSH_RETURN_ERROR);
 	}
 }
+

--- a/bin/ksh/var.c
+++ b/bin/ksh/var.c
@@ -38,7 +38,7 @@ static struct tbl *arraysearch  ARGS((struct tbl *, int));
  * assume caller has allocated and set up e->loc
  */
 void
-newblock(void)
+newblock()
 {
 	register struct block *l;
 	static char *const empty[] = {null};
@@ -64,7 +64,7 @@ newblock(void)
  * pop a block handling special variables
  */
 void
-popblock(void)
+popblock()
 {
 	register struct block *l = e->loc;
 	register struct tbl *vp, **vpp = l->vars.tbls, *vq;
@@ -87,7 +87,7 @@ popblock(void)
 
 /* called by main() to initialize variable data structures */
 void
-initvar(void)
+initvar()
 {
 	static const struct {
 		const char *name;
@@ -136,7 +136,10 @@ initvar(void)
 const char *array_index_calc(const char *n, bool_t *arrayp, int *valp);
 
 const char *
-array_index_calc(const char *n, bool_t *arrayp, int *valp)
+array_index_calc(n, arrayp, valp)
+	const char *n;
+	bool_t *arrayp;
+	int *valp;
 {
 	const char *p;
 	int len;
@@ -166,7 +169,8 @@ array_index_calc(const char *n, bool_t *arrayp, int *valp)
  * Search for variable, if not found create globally.
  */
 struct tbl *
-global(register const char *n)
+global(n)
+	register const char *n;
 {
 	register struct block *l = e->loc;
 	register struct tbl *vp;
@@ -248,7 +252,9 @@ global(register const char *n)
  * Search for local variable, if not found create locally.
  */
 struct tbl *
-local(register const char *n, bool_t copy)
+local(n, copy)
+	register const char *n;
+	bool_t copy;
 {
 	register struct block *l = e->loc;
 	register struct tbl *vp;
@@ -292,7 +298,8 @@ local(register const char *n, bool_t copy)
 
 /* get variable string value */
 char *
-str_val(register struct tbl *vp)
+str_val(vp)
+	register struct tbl *vp;
 {
 	char *s;
 
@@ -344,7 +351,8 @@ str_val(register struct tbl *vp)
 
 /* get variable integer value, with error checking */
 long
-intval(register struct tbl *vp)
+intval(vp)
+	register struct tbl *vp;
 {
 	long num;
 	int base;
@@ -358,7 +366,10 @@ intval(register struct tbl *vp)
 
 /* set variable to string value */
 int
-setstr(register struct tbl *vq, const char *s, int error_ok)
+setstr(vq, s, error_ok)
+	register struct tbl *vq;
+	const char *s;
+	int error_ok;
 {
 	char *fs = NULL;
 	int no_ro_check = error_ok & 0x4;
@@ -402,7 +413,9 @@ setstr(register struct tbl *vq, const char *s, int error_ok)
 
 /* set variable to integer */
 void
-setint(register struct tbl *vq, long n)
+setint(vq, n)
+	register struct tbl *vq;
+	long n;
 {
 	if (!(vq->flag&INTEGER)) {
 		register struct tbl *vp = &vtemp;
@@ -420,7 +433,9 @@ setint(register struct tbl *vq, long n)
 }
 
 int
-getint(struct tbl *vp, long *nump)
+getint(vp, nump)
+	struct tbl *vp;
+	long *nump;
 {
 	register char *s;
 	register int c;
@@ -484,7 +499,8 @@ getint(struct tbl *vp, long *nump)
  * (vq and vp may be the same)
  */
 struct tbl *
-setint_v(register struct tbl *vq, register struct tbl *vp)
+setint_v(vq, vp)
+	register struct tbl *vq, *vp;
 {
 	int base;
 	long num;
@@ -505,7 +521,9 @@ setint_v(register struct tbl *vq, register struct tbl *vp)
 }
 
 static char *
-formatstr(struct tbl *vp, const char *s)
+formatstr(vp, s)
+	struct tbl *vp;
+	const char *s;
 {
 	int olen, nlen;
 	char *p, *q;
@@ -567,7 +585,9 @@ formatstr(struct tbl *vp, const char *s)
  * make vp->val.s be "name=value" for quick exporting.
  */
 static void
-export(register struct tbl *vp, const char *val)
+export(vp, val)
+	register struct tbl *vp;
+	const char *val;
 {
 	register char *xp;
 	char *op = (vp->flag&ALLOC) ? vp->val.s : NULL;
@@ -591,7 +611,10 @@ export(register struct tbl *vp, const char *val)
  * LCASEV, UCASEV_AL), and optionally set its value if an assignment.
  */
 struct tbl *
-typeset(register const char *var, Tflag set, Tflag clr, int field, int base)
+typeset(var, set, clr, field, base)
+	register const char *var;
+	Tflag clr, set;
+	int field, base;
 {
 	register struct tbl *vp;
 	struct tbl *vpbase, *t;
@@ -742,7 +765,9 @@ typeset(register const char *var, Tflag set, Tflag clr, int field, int base)
  * the name lookup (eg, x[2]).
  */
 void
-unset(register struct tbl *vp, int array_ref)
+unset(vp, array_ref)
+	register struct tbl *vp;
+	int array_ref;
 {
 	if (vp->flag & ALLOC)
 		afree((void*)vp->val.s, vp->areap);
@@ -770,7 +795,9 @@ unset(register struct tbl *vp, int array_ref)
  * null if whole string is legal).
  */
 char *
-skip_varname(const char *s, int aok)
+skip_varname(s, aok)
+	const char *s;
+	int aok;
 {
 	int alen;
 
@@ -783,11 +810,11 @@ skip_varname(const char *s, int aok)
 	return (char *) __UNCONST(s);
 }
 
-/* Return a pointer to the first character past any legal variable name.
- * aok - skip array de-reference?
- */
+/* Return a pointer to the first character past any legal variable name.  */
 char *
-skip_wdvarname(const char *s, int aok)
+skip_wdvarname(s, aok)
+	const char *s;
+	int aok;	/* skip array de-reference? */
 {
 	if (s[0] == CHAR && letter(s[1])) {
 		do
@@ -818,7 +845,9 @@ skip_wdvarname(const char *s, int aok)
 
 /* Check if coded string s is a variable name */
 int
-is_wdvarname(const char *s, int aok)
+is_wdvarname(s, aok)
+	const char *s;
+	int aok;
 {
 	char *p = skip_wdvarname(s, aok);
 
@@ -827,7 +856,8 @@ is_wdvarname(const char *s, int aok)
 
 /* Check if coded string s is a variable assignment */
 int
-is_wdvarassign(const char *s)
+is_wdvarassign(s)
+	const char *s;
 {
 	char *p = skip_wdvarname(s, TRUE);
 
@@ -838,7 +868,7 @@ is_wdvarassign(const char *s)
  * Make the exported environment from the exported names in the dictionary.
  */
 char **
-makenv(void)
+makenv()
 {
 	struct block *l = e->loc;
 	XPtrV env;
@@ -880,7 +910,7 @@ makenv(void)
  * if the parent doesn't use $RANDOM.
  */
 void
-change_random(void)
+change_random()
 {
     rand();
 }
@@ -891,7 +921,8 @@ change_random(void)
 
 /* Test if name is a special parameter */
 static int
-special(register const char *name)
+special(name)
+	register const char * name;
 {
 	register struct tbl *tp;
 
@@ -901,7 +932,8 @@ special(register const char *name)
 
 /* Make a variable non-special */
 static void
-unspecial(register const char *name)
+unspecial(name)
+	register const char * name;
 {
 	register struct tbl *tp;
 
@@ -916,7 +948,8 @@ static	time_t	seconds;		/* time SECONDS last set */
 static	int	user_lineno;		/* what user set $LINENO to */
 
 static void
-getspec(register struct tbl *vp)
+getspec(vp)
+	register struct tbl *vp;
 {
 	switch (special(vp->name)) {
 #ifdef KSH
@@ -957,7 +990,8 @@ getspec(register struct tbl *vp)
 }
 
 static void
-setspec(register struct tbl *vp)
+setspec(vp)
+	register struct tbl *vp;
 {
 	char *s;
 
@@ -1057,7 +1091,8 @@ setspec(register struct tbl *vp)
 }
 
 static void
-unsetspec(register struct tbl *vp)
+unsetspec(vp)
+	register struct tbl *vp;
 {
 	switch (special(vp->name)) {
 	  case V_PATH:
@@ -1115,7 +1150,9 @@ unsetspec(register struct tbl *vp)
  * vp, indexed by val.
  */
 static struct tbl *
-arraysearch(struct tbl *vp, int val)
+arraysearch(vp, val)
+	struct tbl *vp;
+	int val;
 {
 	struct tbl *prev, *curr, *new;
 	size_t namelen = strlen(vp->name) + 1;
@@ -1159,7 +1196,8 @@ arraysearch(struct tbl *vp, int val)
  * bracket.
  */
 int
-array_ref_len(const char *cp)
+array_ref_len(cp)
+	const char *cp;
 {
 	const char *s = cp;
 	int c;
@@ -1177,7 +1215,8 @@ array_ref_len(const char *cp)
  * Make a copy of the base of an array name
  */
 char *
-arrayname(const char *str)
+arrayname(str)
+	const char *str;
 {
 	const char *p;
 
@@ -1191,7 +1230,10 @@ arrayname(const char *str)
 /* Set (or overwrite, if !reset) the array variable var to the values in vals.
  */
 void
-set_array(const char *var, int reset, char **vals)
+set_array(var, reset, vals)
+	const char *var;
+	int reset;
+	char **vals;
 {
 	struct tbl *vp, *vq;
 	int i;
@@ -1216,4 +1258,3 @@ set_array(const char *var, int reset, char **vals)
 		setstr(vq, vals[i], KSH_RETURN_ERROR);
 	}
 }
-

--- a/bin/ksh/version.c
+++ b/bin/ksh/version.c
@@ -14,4 +14,3 @@ __RCSID("$NetBSD: version.c,v 1.5 2005/06/26 19:09:00 christos Exp $");
 
 char ksh_version [] =
 	"@(#)PD KSH v5.2.14 99/07/13.2";
-

--- a/bin/ksh/version.c
+++ b/bin/ksh/version.c
@@ -14,3 +14,4 @@ __RCSID("$NetBSD: version.c,v 1.5 2005/06/26 19:09:00 christos Exp $");
 
 char ksh_version [] =
 	"@(#)PD KSH v5.2.14 99/07/13.2";
+

--- a/bin/ksh/vi.c
+++ b/bin/ksh/vi.c
@@ -194,7 +194,9 @@ enum expand_mode { NONE, EXPAND, COMPLETE, PRINT };
 static enum expand_mode expanded = NONE;/* last input was expanded */
 
 int
-x_vi(char *buf, size_t len)
+x_vi(buf, len)
+	char	*buf;
+	size_t	len;
 {
 	int	c;
 
@@ -254,7 +256,8 @@ x_vi(char *buf, size_t len)
 }
 
 static int
-vi_hook(int ch)
+vi_hook(ch)
+	int		ch;
 {
 	static char	curcmd[MAXVICMD];
 	static char	locpat[SRCHLEN];
@@ -551,7 +554,9 @@ vi_hook(int ch)
 }
 
 static void
-vi_reset(char *buf, size_t len)
+vi_reset(buf, len)
+	char	*buf;
+	size_t	len;
 {
 	state = VNORMAL;
 	ohnum = hnum = hlast = histnum(-1) + 1;
@@ -565,7 +570,8 @@ vi_reset(char *buf, size_t len)
 }
 
 static int
-nextstate(int ch)
+nextstate(ch)
+	int	ch;
 {
 	if (is_extend(ch))
 		return VEXTCMD;
@@ -584,7 +590,8 @@ nextstate(int ch)
 }
 
 static int
-vi_insert(int ch)
+vi_insert(ch)
+	int	ch;
 {
 	int	tcursor;
 
@@ -716,7 +723,9 @@ vi_insert(int ch)
 }
 
 static int
-vi_cmd(int argcnt, const char *cmd)
+vi_cmd(argcnt, cmd)
+	int		argcnt;
+	const char	*cmd;
 {
 	int		ncursor;
 	int		cur, c1, c2, c3 = 0;
@@ -1167,7 +1176,10 @@ vi_cmd(int argcnt, const char *cmd)
 }
 
 static int
-domove(int argcnt, const char *cmd, int sub)
+domove(argcnt, cmd, sub)
+	int	argcnt;
+	const char *cmd;
+	int	sub;
 {
 	int	bcount, UNINITIALIZED(i), t;
 	int	UNINITIALIZED(ncursor);
@@ -1314,7 +1326,8 @@ domove(int argcnt, const char *cmd, int sub)
 }
 
 static int
-redo_insert(int count)
+redo_insert(count)
+	int	count;
 {
 	while (count-- > 0)
 		if (putbuf(ibuf, inslen, insert==REPLACE) != 0)
@@ -1326,7 +1339,8 @@ redo_insert(int count)
 }
 
 static void
-yank_range(int a, int b)
+yank_range(a, b)
+	int	a, b;
 {
 	yanklen = b - a;
 	if (yanklen != 0)
@@ -1334,7 +1348,8 @@ yank_range(int a, int b)
 }
 
 static int
-bracktype(int ch)
+bracktype(ch)
+	int	ch;
 {
 	switch (ch) {
 
@@ -1379,7 +1394,7 @@ static char	holdbuf[CMDLEN];	/* place to hold last edit buffer */
 static int	holdlen;		/* length of holdbuf */
 
 static void
-save_cbuf(void)
+save_cbuf()
 {
 	memmove(holdbuf, es->cbuf, es->linelen);
 	holdlen = es->linelen;
@@ -1387,7 +1402,7 @@ save_cbuf(void)
 }
 
 static void
-restore_cbuf(void)
+restore_cbuf()
 {
 	es->cursor = 0;
 	es->linelen = holdlen;
@@ -1396,7 +1411,8 @@ restore_cbuf(void)
 
 /* return a new edstate */
 static struct edstate *
-save_edstate(struct edstate *old)
+save_edstate(old)
+	struct edstate *old;
 {
 	struct edstate *new;
 
@@ -1411,7 +1427,8 @@ save_edstate(struct edstate *old)
 }
 
 static void
-restore_edstate(struct edstate *new, struct edstate *old)
+restore_edstate(new, old)
+	struct edstate *old, *new;
 {
 	memcpy(new->cbuf, old->cbuf, old->linelen);
 	new->linelen = old->linelen;
@@ -1421,7 +1438,8 @@ restore_edstate(struct edstate *new, struct edstate *old)
 }
 
 static void
-free_edstate(struct edstate *old)
+free_edstate(old)
+	struct edstate *old;
 {
 	afree(old->cbuf, APERM);
 	afree((char *)old, APERM);
@@ -1430,7 +1448,9 @@ free_edstate(struct edstate *old)
 
 
 static void
-edit_reset(char *buf, size_t len)
+edit_reset(buf, len)
+	char	*buf;
+	size_t	len;
 {
 	const char *p;
 
@@ -1470,13 +1490,18 @@ edit_reset(char *buf, size_t len)
  * this is used for calling x_escape() in complete_word()
  */
 static int
-x_vi_putbuf(const char *s, size_t len)
+x_vi_putbuf(s, len)
+	const char *s;
+	size_t len;
 {
 	return putbuf(s, len, 0);
 }
 
 static int
-putbuf(const char *buf, int len, int repl)
+putbuf(buf, len, repl)
+	const char *buf;
+	int	len;
+	int	repl;
 {
 	if (len == 0)
 		return 0;
@@ -1498,7 +1523,8 @@ putbuf(const char *buf, int len, int repl)
 }
 
 static void
-del_range(int a, int b)
+del_range(a, b)
+	int	a, b;
 {
 	if (es->linelen != b)
 		memmove(&es->cbuf[a], &es->cbuf[b], es->linelen - b);
@@ -1506,7 +1532,11 @@ del_range(int a, int b)
 }
 
 static int
-findch(int ch, int cnt, int forw, int incl)
+findch(ch, cnt, forw, incl)
+	int	ch;
+	int	cnt;
+	int	forw;
+	int	incl;
 {
 	int	ncursor;
 
@@ -1535,6 +1565,7 @@ findch(int ch, int cnt, int forw, int incl)
 
 static int
 forwword(argcnt)
+	int	argcnt;
 {
 	int	ncursor;
 
@@ -1556,7 +1587,8 @@ forwword(argcnt)
 }
 
 static int
-backword(int argcnt)
+backword(argcnt)
+	int	argcnt;
 {
 	int	ncursor;
 
@@ -1581,7 +1613,8 @@ backword(int argcnt)
 }
 
 static int
-endword(int argcnt)
+endword(argcnt)
+	int	argcnt;
 {
 	int	ncursor;
 
@@ -1607,7 +1640,8 @@ endword(int argcnt)
 }
 
 static int
-Forwword(int argcnt)
+Forwword(argcnt)
+	int	argcnt;
 {
 	int	ncursor;
 
@@ -1622,7 +1656,8 @@ Forwword(int argcnt)
 }
 
 static int
-Backword(int argcnt)
+Backword(argcnt)
+	int	argcnt;
 {
 	int	ncursor;
 
@@ -1638,7 +1673,8 @@ Backword(int argcnt)
 }
 
 static int
-Endword(int argcnt)
+Endword(argcnt)
+	int	argcnt;
 {
 	int	ncursor;
 
@@ -1658,7 +1694,9 @@ Endword(int argcnt)
 }
 
 static int
-grabhist(int save, int n)
+grabhist(save, n)
+	int	save;
+	int	n;
 {
 	char	*hptr;
 
@@ -1685,7 +1723,9 @@ grabhist(int save, int n)
 }
 
 static int
-grabsearch(int save, int start, int fwd, char *pat)
+grabsearch(save, start, fwd, pat)
+	int	save, start, fwd;
+	char	*pat;
 {
 	char	*hptr;
 	int	hist;
@@ -1719,7 +1759,8 @@ grabsearch(int save, int start, int fwd, char *pat)
 }
 
 static void
-redraw_line(int newlinex)
+redraw_line(newlinex)
+	int newlinex;
 {
 	(void) memset(wbuf[win], ' ', wbuf_len);
 	if (newlinex) {
@@ -1732,7 +1773,8 @@ redraw_line(int newlinex)
 }
 
 static void
-refresh(int leftside)
+refresh(leftside)
+	int		leftside;
 {
 	if (leftside < 0)
 		leftside = lastref;
@@ -1745,7 +1787,7 @@ refresh(int leftside)
 }
 
 static int
-outofwin(void)
+outofwin()
 {
 	int	cur, col;
 
@@ -1761,7 +1803,7 @@ outofwin(void)
 }
 
 static void
-rewindow(void)
+rewindow()
 {
 	register int	tcur, tcol;
 	int		holdcur1, holdcol1;
@@ -1785,7 +1827,8 @@ rewindow(void)
 }
 
 static int
-newcol(int ch, int col)
+newcol(ch, col)
+	int	ch, col;
 {
 	if (ch == '\t')
 		return (col | 7) + 1;
@@ -1793,7 +1836,9 @@ newcol(int ch, int col)
 }
 
 static void
-display(char *wb1, char *wb2, int leftside)
+display(wb1, wb2, leftside)
+	char	*wb1, *wb2;
+	int	leftside;
 {
 	unsigned char ch;
 	char	*twb1, *twb2, mc;
@@ -1886,7 +1931,9 @@ display(char *wb1, char *wb2, int leftside)
 }
 
 static void
-ed_mov_opt(int col, char *wb)
+ed_mov_opt(col, wb)
+	int	col;
+	char	*wb;
 {
 	if (col < cur_col) {
 		if (col + 1 < cur_col - col) {
@@ -1910,7 +1957,8 @@ ed_mov_opt(int col, char *wb)
 
 /* replace word with all expansions (ie, expand word*) */
 static int
-expand_word(int commandx)
+expand_word(commandx)
+	int commandx;
 {
 	static struct edstate *buf;
 	int rval = 0;
@@ -1964,7 +2012,9 @@ expand_word(int commandx)
 }
 
 static int
-complete_word(int commandx, int count)
+complete_word(commandx, count)
+	int commandx;
+	int count;
 {
 	static struct edstate *buf;
 	int rval = 0;
@@ -2071,7 +2121,9 @@ complete_word(int commandx, int count)
 }
 
 static int
-print_expansions(struct edstate *ex, int commandx)
+print_expansions(ex, commandx)
+	struct edstate *ex;
+	int	commandx;
 {
 	int nwords;
 	int start, end;
@@ -2093,7 +2145,8 @@ print_expansions(struct edstate *ex, int commandx)
 
 /* How long is char when displayed (not counting tabs) */
 static int
-char_len(int c)
+char_len(c)
+	int c;
 {
 	int len = 1;
 
@@ -2108,7 +2161,8 @@ char_len(int c)
 
 /* Similar to x_zotc(emacs.c), but no tab weirdness */
 static void
-x_vi_zotc(int c)
+x_vi_zotc(c)
+	int c;
 {
 	if (Flag(FVISHOW8) && (c & 0x80)) {
 		x_puts("M-");
@@ -2122,13 +2176,14 @@ x_vi_zotc(int c)
 }
 
 static void
-vi_pprompt(int full)
+vi_pprompt(full)
+	int full;
 {
 	pprompt(prompt + (full ? 0 : prompt_skip), prompt_trunc);
 }
 
 static void
-vi_error(void)
+vi_error()
 {
 	/* Beem out of any macros as soon as an error occurs */
 	vi_macro_reset();
@@ -2137,7 +2192,7 @@ vi_error(void)
 }
 
 static void
-vi_macro_reset(void)
+vi_macro_reset()
 {
 	if (macro.p) {
 		afree(macro.buf, APERM);
@@ -2146,4 +2201,3 @@ vi_macro_reset(void)
 }
 
 #endif	/* VI */
-

--- a/bin/ksh/vi.c
+++ b/bin/ksh/vi.c
@@ -194,9 +194,7 @@ enum expand_mode { NONE, EXPAND, COMPLETE, PRINT };
 static enum expand_mode expanded = NONE;/* last input was expanded */
 
 int
-x_vi(buf, len)
-	char	*buf;
-	size_t	len;
+x_vi(char *buf, size_t len)
 {
 	int	c;
 
@@ -256,8 +254,7 @@ x_vi(buf, len)
 }
 
 static int
-vi_hook(ch)
-	int		ch;
+vi_hook(int ch)
 {
 	static char	curcmd[MAXVICMD];
 	static char	locpat[SRCHLEN];
@@ -554,9 +551,7 @@ vi_hook(ch)
 }
 
 static void
-vi_reset(buf, len)
-	char	*buf;
-	size_t	len;
+vi_reset(char *buf, size_t len)
 {
 	state = VNORMAL;
 	ohnum = hnum = hlast = histnum(-1) + 1;
@@ -570,8 +565,7 @@ vi_reset(buf, len)
 }
 
 static int
-nextstate(ch)
-	int	ch;
+nextstate(int ch)
 {
 	if (is_extend(ch))
 		return VEXTCMD;
@@ -590,8 +584,7 @@ nextstate(ch)
 }
 
 static int
-vi_insert(ch)
-	int	ch;
+vi_insert(int ch)
 {
 	int	tcursor;
 
@@ -723,9 +716,7 @@ vi_insert(ch)
 }
 
 static int
-vi_cmd(argcnt, cmd)
-	int		argcnt;
-	const char	*cmd;
+vi_cmd(int argcnt, const char *cmd)
 {
 	int		ncursor;
 	int		cur, c1, c2, c3 = 0;
@@ -1176,10 +1167,7 @@ vi_cmd(argcnt, cmd)
 }
 
 static int
-domove(argcnt, cmd, sub)
-	int	argcnt;
-	const char *cmd;
-	int	sub;
+domove(int argcnt, const char *cmd, int sub)
 {
 	int	bcount, UNINITIALIZED(i), t;
 	int	UNINITIALIZED(ncursor);
@@ -1326,8 +1314,7 @@ domove(argcnt, cmd, sub)
 }
 
 static int
-redo_insert(count)
-	int	count;
+redo_insert(int count)
 {
 	while (count-- > 0)
 		if (putbuf(ibuf, inslen, insert==REPLACE) != 0)
@@ -1339,8 +1326,7 @@ redo_insert(count)
 }
 
 static void
-yank_range(a, b)
-	int	a, b;
+yank_range(int a, int b)
 {
 	yanklen = b - a;
 	if (yanklen != 0)
@@ -1348,8 +1334,7 @@ yank_range(a, b)
 }
 
 static int
-bracktype(ch)
-	int	ch;
+bracktype(int ch)
 {
 	switch (ch) {
 
@@ -1394,7 +1379,7 @@ static char	holdbuf[CMDLEN];	/* place to hold last edit buffer */
 static int	holdlen;		/* length of holdbuf */
 
 static void
-save_cbuf()
+save_cbuf(void)
 {
 	memmove(holdbuf, es->cbuf, es->linelen);
 	holdlen = es->linelen;
@@ -1402,7 +1387,7 @@ save_cbuf()
 }
 
 static void
-restore_cbuf()
+restore_cbuf(void)
 {
 	es->cursor = 0;
 	es->linelen = holdlen;
@@ -1411,8 +1396,7 @@ restore_cbuf()
 
 /* return a new edstate */
 static struct edstate *
-save_edstate(old)
-	struct edstate *old;
+save_edstate(struct edstate *old)
 {
 	struct edstate *new;
 
@@ -1427,8 +1411,7 @@ save_edstate(old)
 }
 
 static void
-restore_edstate(new, old)
-	struct edstate *old, *new;
+restore_edstate(struct edstate *new, struct edstate *old)
 {
 	memcpy(new->cbuf, old->cbuf, old->linelen);
 	new->linelen = old->linelen;
@@ -1438,8 +1421,7 @@ restore_edstate(new, old)
 }
 
 static void
-free_edstate(old)
-	struct edstate *old;
+free_edstate(struct edstate *old)
 {
 	afree(old->cbuf, APERM);
 	afree((char *)old, APERM);
@@ -1448,9 +1430,7 @@ free_edstate(old)
 
 
 static void
-edit_reset(buf, len)
-	char	*buf;
-	size_t	len;
+edit_reset(char *buf, size_t len)
 {
 	const char *p;
 
@@ -1490,18 +1470,13 @@ edit_reset(buf, len)
  * this is used for calling x_escape() in complete_word()
  */
 static int
-x_vi_putbuf(s, len)
-	const char *s;
-	size_t len;
+x_vi_putbuf(const char *s, size_t len)
 {
 	return putbuf(s, len, 0);
 }
 
 static int
-putbuf(buf, len, repl)
-	const char *buf;
-	int	len;
-	int	repl;
+putbuf(const char *buf, int len, int repl)
 {
 	if (len == 0)
 		return 0;
@@ -1523,8 +1498,7 @@ putbuf(buf, len, repl)
 }
 
 static void
-del_range(a, b)
-	int	a, b;
+del_range(int a, int b)
 {
 	if (es->linelen != b)
 		memmove(&es->cbuf[a], &es->cbuf[b], es->linelen - b);
@@ -1532,11 +1506,7 @@ del_range(a, b)
 }
 
 static int
-findch(ch, cnt, forw, incl)
-	int	ch;
-	int	cnt;
-	int	forw;
-	int	incl;
+findch(int ch, int cnt, int forw, int incl)
 {
 	int	ncursor;
 
@@ -1565,7 +1535,6 @@ findch(ch, cnt, forw, incl)
 
 static int
 forwword(argcnt)
-	int	argcnt;
 {
 	int	ncursor;
 
@@ -1587,8 +1556,7 @@ forwword(argcnt)
 }
 
 static int
-backword(argcnt)
-	int	argcnt;
+backword(int argcnt)
 {
 	int	ncursor;
 
@@ -1613,8 +1581,7 @@ backword(argcnt)
 }
 
 static int
-endword(argcnt)
-	int	argcnt;
+endword(int argcnt)
 {
 	int	ncursor;
 
@@ -1640,8 +1607,7 @@ endword(argcnt)
 }
 
 static int
-Forwword(argcnt)
-	int	argcnt;
+Forwword(int argcnt)
 {
 	int	ncursor;
 
@@ -1656,8 +1622,7 @@ Forwword(argcnt)
 }
 
 static int
-Backword(argcnt)
-	int	argcnt;
+Backword(int argcnt)
 {
 	int	ncursor;
 
@@ -1673,8 +1638,7 @@ Backword(argcnt)
 }
 
 static int
-Endword(argcnt)
-	int	argcnt;
+Endword(int argcnt)
 {
 	int	ncursor;
 
@@ -1694,9 +1658,7 @@ Endword(argcnt)
 }
 
 static int
-grabhist(save, n)
-	int	save;
-	int	n;
+grabhist(int save, int n)
 {
 	char	*hptr;
 
@@ -1723,9 +1685,7 @@ grabhist(save, n)
 }
 
 static int
-grabsearch(save, start, fwd, pat)
-	int	save, start, fwd;
-	char	*pat;
+grabsearch(int save, int start, int fwd, char *pat)
 {
 	char	*hptr;
 	int	hist;
@@ -1759,8 +1719,7 @@ grabsearch(save, start, fwd, pat)
 }
 
 static void
-redraw_line(newlinex)
-	int newlinex;
+redraw_line(int newlinex)
 {
 	(void) memset(wbuf[win], ' ', wbuf_len);
 	if (newlinex) {
@@ -1773,8 +1732,7 @@ redraw_line(newlinex)
 }
 
 static void
-refresh(leftside)
-	int		leftside;
+refresh(int leftside)
 {
 	if (leftside < 0)
 		leftside = lastref;
@@ -1787,7 +1745,7 @@ refresh(leftside)
 }
 
 static int
-outofwin()
+outofwin(void)
 {
 	int	cur, col;
 
@@ -1803,7 +1761,7 @@ outofwin()
 }
 
 static void
-rewindow()
+rewindow(void)
 {
 	register int	tcur, tcol;
 	int		holdcur1, holdcol1;
@@ -1827,8 +1785,7 @@ rewindow()
 }
 
 static int
-newcol(ch, col)
-	int	ch, col;
+newcol(int ch, int col)
 {
 	if (ch == '\t')
 		return (col | 7) + 1;
@@ -1836,9 +1793,7 @@ newcol(ch, col)
 }
 
 static void
-display(wb1, wb2, leftside)
-	char	*wb1, *wb2;
-	int	leftside;
+display(char *wb1, char *wb2, int leftside)
 {
 	unsigned char ch;
 	char	*twb1, *twb2, mc;
@@ -1931,9 +1886,7 @@ display(wb1, wb2, leftside)
 }
 
 static void
-ed_mov_opt(col, wb)
-	int	col;
-	char	*wb;
+ed_mov_opt(int col, char *wb)
 {
 	if (col < cur_col) {
 		if (col + 1 < cur_col - col) {
@@ -1957,8 +1910,7 @@ ed_mov_opt(col, wb)
 
 /* replace word with all expansions (ie, expand word*) */
 static int
-expand_word(commandx)
-	int commandx;
+expand_word(int commandx)
 {
 	static struct edstate *buf;
 	int rval = 0;
@@ -2012,9 +1964,7 @@ expand_word(commandx)
 }
 
 static int
-complete_word(commandx, count)
-	int commandx;
-	int count;
+complete_word(int commandx, int count)
 {
 	static struct edstate *buf;
 	int rval = 0;
@@ -2121,9 +2071,7 @@ complete_word(commandx, count)
 }
 
 static int
-print_expansions(ex, commandx)
-	struct edstate *ex;
-	int	commandx;
+print_expansions(struct edstate *ex, int commandx)
 {
 	int nwords;
 	int start, end;
@@ -2145,8 +2093,7 @@ print_expansions(ex, commandx)
 
 /* How long is char when displayed (not counting tabs) */
 static int
-char_len(c)
-	int c;
+char_len(int c)
 {
 	int len = 1;
 
@@ -2161,8 +2108,7 @@ char_len(c)
 
 /* Similar to x_zotc(emacs.c), but no tab weirdness */
 static void
-x_vi_zotc(c)
-	int c;
+x_vi_zotc(int c)
 {
 	if (Flag(FVISHOW8) && (c & 0x80)) {
 		x_puts("M-");
@@ -2176,14 +2122,13 @@ x_vi_zotc(c)
 }
 
 static void
-vi_pprompt(full)
-	int full;
+vi_pprompt(int full)
 {
 	pprompt(prompt + (full ? 0 : prompt_skip), prompt_trunc);
 }
 
 static void
-vi_error()
+vi_error(void)
 {
 	/* Beem out of any macros as soon as an error occurs */
 	vi_macro_reset();
@@ -2192,7 +2137,7 @@ vi_error()
 }
 
 static void
-vi_macro_reset()
+vi_macro_reset(void)
 {
 	if (macro.p) {
 		afree(macro.buf, APERM);
@@ -2201,3 +2146,4 @@ vi_macro_reset()
 }
 
 #endif	/* VI */
+

--- a/minix/commands/dhrystone/dhrystone.c
+++ b/minix/commands/dhrystone/dhrystone.c
@@ -211,7 +211,7 @@ boolean Func3(Enumeration EnumParIn);
 Enumeration Func1(int CharPar1, int CharPar2);
 
 
-int main()
+int main(void)
 {
   Proc0();
   return(0);
@@ -224,14 +224,13 @@ volatile int done;
 int done;
 #endif
 
-void prep_timer()
+void prep_timer(void)
 {
   signal(SIGALRM, timeout);
   done = 0;
 }
 
-void timeout(sig)
-int sig;
+void timeout(int sig)
 {
   done = 1;
 }
@@ -247,7 +246,7 @@ RecordPtr PtrGlb;
 RecordPtr PtrGlbNext;
 
 
-void Proc0()
+void Proc0(void)
 {
   OneToFifty IntLoc1;
   REG OneToFifty IntLoc2;
@@ -383,8 +382,7 @@ void Proc0()
 }
 
 
-void Proc1(PtrParIn)
-REG RecordPtr PtrParIn;
+void Proc1(REG RecordPtr PtrParIn)
 {
 #define	NextRecord	(*(PtrParIn->PtrComp))
 
@@ -407,8 +405,7 @@ REG RecordPtr PtrParIn;
 }
 
 
-void Proc2(IntParIO)
-OneToFifty *IntParIO;
+void Proc2(OneToFifty *IntParIO)
 {
   REG OneToFifty IntLoc;
   REG Enumeration EnumLoc;
@@ -426,8 +423,7 @@ OneToFifty *IntParIO;
 }
 
 
-void Proc3(PtrParOut)
-RecordPtr *PtrParOut;
+void Proc3(RecordPtr *PtrParOut)
 {
   if (PtrGlb != NULL)
 	*PtrParOut = PtrGlb->PtrComp;
@@ -437,7 +433,7 @@ RecordPtr *PtrParOut;
 }
 
 
-void Proc4()
+void Proc4(void)
 {
   REG boolean BoolLoc;
 
@@ -448,16 +444,14 @@ void Proc4()
 }
 
 
-void Proc5()
+void Proc5(void)
 {
   Char1Glob = 'A';
   BoolGlob = FALSE;
 }
 
 
-void Proc6(EnumParIn, EnumParOut)
-REG Enumeration EnumParIn;
-REG Enumeration *EnumParOut;
+void Proc6(REG Enumeration EnumParIn, REG Enumeration *EnumParOut)
 {
   *EnumParOut = EnumParIn;
   if (!Func3(EnumParIn)) *EnumParOut = Ident4;
@@ -477,10 +471,7 @@ REG Enumeration *EnumParOut;
 }
 
 
-void Proc7(IntParI1, IntParI2, IntParOut)
-OneToFifty IntParI1;
-OneToFifty IntParI2;
-OneToFifty *IntParOut;
+void Proc7(OneToFifty IntParI1, OneToFifty IntParI2, OneToFifty *IntParOut)
 {
   REG OneToFifty IntLoc;
 
@@ -490,11 +481,8 @@ OneToFifty *IntParOut;
 }
 
 
-void Proc8(Array1Par, Array2Par, IntParI1, IntParI2)
-Array1Dim Array1Par;
-Array2Dim Array2Par;
-OneToFifty IntParI1;
-OneToFifty IntParI2;
+void Proc8(Array1Dim Array1Par, Array2Dim Array2Par,
+		   OneToFifty IntParI1, OneToFifty IntParI2)
 {
   REG OneToFifty IntLoc;
   REG OneToFifty IntIndex;
@@ -512,9 +500,7 @@ OneToFifty IntParI2;
 }
 
 
-Enumeration Func1(CharPar1, CharPar2)
-CapitalLetter CharPar1;
-CapitalLetter CharPar2;
+Enumeration Func1(CapitalLetter CharPar1, CapitalLetter CharPar2)
 {
   REG CapitalLetter CharLoc1;
   REG CapitalLetter CharLoc2;
@@ -529,9 +515,7 @@ CapitalLetter CharPar2;
 }
 
 
-boolean Func2(StrParI1, StrParI2)
-String30 StrParI1;
-String30 StrParI2;
+boolean Func2(String30 StrParI1, String30 StrParI2)
 {
   REG OneToThirty IntLoc;
   REG CapitalLetter CharLoc;
@@ -556,8 +540,7 @@ String30 StrParI2;
 }
 
 
-boolean Func3(EnumParIn)
-REG Enumeration EnumParIn;
+boolean Func3(REG Enumeration EnumParIn)
 {
   REG Enumeration EnumLoc;
 
@@ -569,10 +552,7 @@ REG Enumeration EnumParIn;
 
 
 #ifdef	NOSTRUCTASSIGN
-memcpy(d, s, l)
-register char *d;
-register char *s;
-register int l;
+memcpy(register char *d, register char *s, register int l)
 {
   while (l--) *d++ = *s++;
 }

--- a/minix/commands/dhrystone/dhrystone.c
+++ b/minix/commands/dhrystone/dhrystone.c
@@ -500,7 +500,7 @@ void Proc8(Array1Dim Array1Par, Array2Dim Array2Par,
 }
 
 
-Enumeration Func1(CapitalLetter CharPar1, CapitalLetter CharPar2)
+Enumeration Func1(int CharPar1, int CharPar2)
 {
   REG CapitalLetter CharLoc1;
   REG CapitalLetter CharLoc2;

--- a/minix/commands/dosread/dosread.c
+++ b/minix/commands/dosread/dosread.c
@@ -146,29 +146,26 @@ BOOL free_range(unsigned short *first, unsigned short *last);
 long lmin(long a, long b);
 
 
-void usage(prog_name)
-register char *prog_name;
+void usage(register char *prog_name)
 {
   fprintf (stderr, "Usage: %s [%s\n", prog_name,
 	     (dos_dir ? "-lr] drive [dir]" : "-a] drive file"));
   exit(1);
 }
 
-unsigned c2u2(ucarray)
-unsigned char *ucarray;
+unsigned c2u2(unsigned char *ucarray)
 {
   return ucarray[0] + (ucarray[1] << 8);	/* parens vital */
 }
 
-unsigned long c4u4(ucarray)
-unsigned char *ucarray;
+unsigned long c4u4(unsigned char *ucarray)
 {
   return ucarray[0] + ((unsigned long) ucarray[1] << 8) +
 		      ((unsigned long) ucarray[2] << 16) +
 		      ((unsigned long) ucarray[3] << 24);
 }
 
-void determine()
+void determine(void)
 {
   struct dosboot {
 	unsigned char cjump[2];	/* unsigneds avoid bugs */
@@ -292,9 +289,7 @@ void determine()
   }
 }
 
-int main(argc, argv)
-int argc;
-register char *argv[];
+int main(int argc, register char *argv[])
 {
   register char *arg_ptr = slash(argv[0]);
   DIRECTORY *entry;
@@ -438,11 +433,7 @@ register char *argv[];
  *	separated by slashes, but can be longer than than 
  *	8+3 characters (The rest is ignored).
  */
-DIRECTORY *directory(dir, entries, function, pathname)
-DIRECTORY *dir;
-int entries;
-int function;
-register char *pathname;
+DIRECTORY *directory(DIRECTORY *dir, int entries, int function, register char *pathname)
 {
   register DIRECTORY *dir_ptr = dir;
   DIRECTORY *mem = NULL;
@@ -564,8 +555,7 @@ register char *pathname;
   return NULL;
 }
 
-void extract(entry)
-register DIRECTORY *entry;
+void extract(register DIRECTORY *entry)
 {
   register unsigned short cl_no = entry->d_cluster;
   char buffer[MAX_CLUSTER_SIZE];
@@ -614,18 +604,14 @@ register DIRECTORY *entry;
 
 /* Minimum of two long values
  */
-long lmin (a, b)
-long a, b;
+long lmin (long a, long b)
 {
 	if (a < b) return a;
 	else return b;
 }
 
 
-void make_file(dir_ptr, entries, name)
-DIRECTORY *dir_ptr;
-int entries;
-char *name;
+void make_file(DIRECTORY *dir_ptr, int entries, char *name)
 {
   register DIRECTORY *entry = new_entry(dir_ptr, entries);
   register char *ptr;
@@ -693,8 +679,7 @@ done:
 
 unsigned short mon_len[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
-void fill_date(entry)
-DIRECTORY *entry;
+void fill_date(DIRECTORY *entry)
 {
   register long cur_time = time(NULL) - DOS_TIME;
   unsigned short year = 0, month = 1, day, hour, minutes, seconds;
@@ -733,9 +718,7 @@ DIRECTORY *entry;
   entry->d_time = (hour << 11) | (minutes << 5) | seconds;
 }
 
-char *make_name(dir_ptr, dir_fl)
-register DIRECTORY *dir_ptr;
-short dir_fl;
+char *make_name(register DIRECTORY *dir_ptr, short dir_fl)
 {
   static char name_buf[14];
   register char *ptr = name_buf;
@@ -760,9 +743,7 @@ short dir_fl;
 }
 
 
-int fill(buffer, size)
-register char *buffer;
-size_t	size;
+int fill(register char *buffer, size_t size)
 {
   static BOOL nl_mark = FALSE;
   char *last = &buffer[size];
@@ -799,17 +780,14 @@ char *month[] = {
 	 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
 };
 
-void xmodes(mode)
-int mode;
+void xmodes(int mode)
 {
   printf ( "\t%c%c%c%c%c", (mode & SUB_DIR) ? 'd' : '-',
 	     (mode & 02) ? 'h' : '-', (mode & 04) ? 's' : '-',
 	     (mode & 01) ? '-' : 'w', (mode & 0x20) ? 'a' : '-');
 }
 
-void show(dir_ptr, name)
-DIRECTORY *dir_ptr;
-char *name;
+void show(DIRECTORY *dir_ptr, char *name)
 {
   register unsigned short e_date = dir_ptr->d_date;
   register unsigned short e_time = dir_ptr->d_time;
@@ -837,7 +815,7 @@ char *name;
    month[((e_date & MONTH) >> 5) - 1], ((e_date & YEAR) >> 9) + 1980);
 }
 
-void free_blocks()
+void free_blocks(void)
 {
   register unsigned short cl_no;
   long nr_free = 0;
@@ -856,8 +834,7 @@ void free_blocks()
 }
 
 
-DIRECTORY *read_cluster(cluster)
-register unsigned int cluster;
+DIRECTORY *read_cluster(register unsigned int cluster)
 {
   register DIRECTORY *sub_dir;
 
@@ -879,8 +856,7 @@ static unsigned short cl_index = 2;
  * Warning: Assumes that all of the range is used before the next call
  *	to free_range or free_cluster.
  */
-BOOL free_range (first, last)
-unsigned short *first, *last;
+BOOL free_range (unsigned short *first, unsigned short *last)
 {
   while (cl_index < total_clusters && next_cluster(cl_index) != FREE)
 	cl_index++;
@@ -902,8 +878,7 @@ unsigned short *first, *last;
  * Warning: Assumes that the cluster is used before the next call
  *	to free_range or free_cluster.
  */
-unsigned short free_cluster(leave_fl)
-BOOL leave_fl;
+unsigned short free_cluster(BOOL leave_fl)
 {
   while (cl_index < total_clusters && next_cluster(cl_index) != FREE)
 	cl_index++;
@@ -918,8 +893,7 @@ BOOL leave_fl;
 
 /* read a portion of the fat containing |cl_no| into the cache
  */
-void read_fat (cl_no) 
-  unsigned int cl_no;
+void read_fat (unsigned int cl_no) 
 {
 
   if (!cooked_fat) {
@@ -999,7 +973,7 @@ void read_fat (cl_no)
 
 /* flush the fat cache out to disk
  */
-void flush_fat ()
+void flush_fat (void)
 {
   if (fat_16) {
 	if (big_endian) {
@@ -1037,9 +1011,7 @@ void flush_fat ()
 
 /* make cl_2 the successor of cl_1
  */
-void link_fat(cl_1, cl_2)
-unsigned int cl_1;
-unsigned int cl_2;
+void link_fat(unsigned int cl_1, unsigned int cl_2)
 {
   if (cl_1 < fat_low || cl_1 > fat_high) {
   	if (fat_dirty) flush_fat ();
@@ -1050,8 +1022,7 @@ unsigned int cl_2;
 }
 
 
-unsigned short next_cluster(cl_no)
-register unsigned int cl_no;
+unsigned short next_cluster(register unsigned int cl_no)
 {
   if (cl_no < fat_low || cl_no > fat_high) {
   	if (fat_dirty) flush_fat ();
@@ -1060,8 +1031,7 @@ register unsigned int cl_no;
   return cooked_fat [cl_no - fat_low];
 }
 
-char *slash(str)
-register char *str;
+char *slash(register char *str)
 {
   register char *result = str;
 
@@ -1071,9 +1041,7 @@ register char *str;
   return result;
 }
 
-void add_path(file, slash_fl)
-char *file;
-BOOL slash_fl;
+void add_path(char *file, BOOL slash_fl)
 {
   register char *ptr = path;
 
@@ -1091,11 +1059,7 @@ BOOL slash_fl;
 }
 
 
-void disk_io(op, seek, address, bytes)
-register BOOL op;
-unsigned long seek;
-void *address;
-register unsigned bytes;
+void disk_io(register BOOL op, unsigned long seek, void *address, register unsigned bytes)
 {
   unsigned int r;
 

--- a/minix/commands/dosread/dosread.c
+++ b/minix/commands/dosread/dosread.c
@@ -718,7 +718,7 @@ void fill_date(DIRECTORY *entry)
   entry->d_time = (hour << 11) | (minutes << 5) | seconds;
 }
 
-char *make_name(register DIRECTORY *dir_ptr, short dir_fl)
+char *make_name(register DIRECTORY *dir_ptr, int dir_fl)
 {
   static char name_buf[14];
   register char *ptr = name_buf;

--- a/minix/commands/fsck.mfs/fsck.c
+++ b/minix/commands/fsck.mfs/fsck.c
@@ -224,7 +224,7 @@ void printtotal(void);
 void chkdev(char *f, char **clist, char **ilist, char **zlist);
 
 /* Initialize the variables used by this program. */
-void initvars()
+void initvars(void)
 {
   register int level;
 
@@ -238,23 +238,20 @@ void initvars()
 }
 
 /* Print the string `s' and exit. */
-void fatal(s)
-char *s;
+void fatal(char *s)
 {
   printf("%s\nfatal\n", s);
   exit(FSCK_EXIT_CHECK_FAILED);
 }
 
 /* Test for end of line. */
-int eoln(c)
-int c;
+int eoln(int c)
 {
   return(c == EOF || c == '\n' || c == '\r');
 }
 
 /* Ask a question and get the answer unless automatic is set. */
-int yes(question)
-char *question;
+int yes(char *question)
 {
   register int c, answerchar;
   static int note = 0;
@@ -280,8 +277,7 @@ char *question;
 }
 
 /* Convert string to integer.  Representation is octal. */
-int atoo(s)
-register char *s;
+int atoo(register char *s)
 {
   register int n = 0;
 
@@ -293,9 +289,7 @@ register char *s;
 }
 
 /* If repairing the file system, print a prompt and get a string from user. */
-int input(buf, size)
-char *buf;
-int size;
+int input(char *buf, int size)
 {
   register char *p = buf;
 
@@ -319,8 +313,7 @@ int size;
 }
 
 /* Allocate some memory and zero it. */
-char *alloc(nelem, elsize)
-unsigned nelem, elsize;
+char *alloc(unsigned nelem, unsigned elsize)
 {
   char *p;
 
@@ -334,8 +327,7 @@ unsigned nelem, elsize;
 }
 
 /* Print the name in a directory entry. */
-void printname(s)
-char *s;
+void printname(char *s)
 {
   register int n = MFS_NAME_MAX;
   int c;
@@ -361,9 +353,7 @@ void printrec(struct stack *sp)
 }
 
 /* Print the current pathname.  */
-void printpath(mode, nlcr)
-int mode;
-int nlcr;
+void printpath(int mode, int nlcr)
 {
   if (ftop->st_next == 0)
 	putchar('/');
@@ -381,7 +371,7 @@ int nlcr;
 }
 
 /* Open the device.  */
-void devopen()
+void devopen(void)
 {
   if ((dev = open(fsck_device,
     (repair || markdirty) ? O_RDWR : O_RDONLY)) < 0) {
@@ -391,7 +381,7 @@ void devopen()
 }
 
 /* Close the device. */
-void devclose()
+void devclose(void)
 {
   if (close(dev) != 0) {
 	perror("close");
@@ -400,9 +390,7 @@ void devclose()
 }
 
 /* Read or write a block. */
-void devio(bno, dir)
-block_nr bno;
-int dir;
+void devio(block_nr bno, int dir)
 {
   off_t r;
 
@@ -437,11 +425,7 @@ printf("%s at block %5d\n", dir == READING ? "reading " : "writing", bno);
 /* Read `size' bytes from the disk starting at block 'block' and
  * byte `offset'.
  */
-void devread(block, offset, buf, size)
-long block;
-long offset;
-char *buf;
-int size;
+void devread(long block, long offset, char *buf, int size)
 {
   if(!block_size) fatal("devread() with unknown block size");
   if (offset >= block_size)
@@ -456,11 +440,7 @@ int size;
 /* Write `size' bytes to the disk starting at block 'block' and
  * byte `offset'.
  */
-void devwrite(block, offset, buf, size)
-long block;
-long offset;
-char *buf;
-int size;
+void devwrite(long block, long offset, char *buf, int size)
 {
   if(!block_size) fatal("devwrite() with unknown block size");
   if (!repair) fatal("internal error (devwrite)");
@@ -476,24 +456,19 @@ int size;
 }
 
 /* Print a string with either a singular or a plural pronoun. */
-void pr(fmt, cnt, s, p)
-char *fmt, *s, *p;
-int cnt;
+void pr(char *fmt, int cnt, char *s, char *p)
 {
   printf(fmt, cnt, cnt == 1 ? s : p);
 }
 
 /* Same as above, but with a long argument */
-void lpr(fmt, cnt, s, p)
-char *fmt, *s, *p;
-long cnt;
+void lpr(char *fmt, long cnt, char *s, char *p)
 {
   printf(fmt, cnt, cnt == 1 ? s : p);
 }
 
 /* Convert string to number. */
-bit_nr getnumber(s)
-register char *s;
+bit_nr getnumber(register char *s)
 {
   register bit_nr n = 0;
 
@@ -505,8 +480,7 @@ register char *s;
 }
 
 /* See if the list pointed to by `argv' contains numbers. */
-char **getlist(argv, type)
-char ***argv, *type;
+char **getlist(char ***argv, char *type)
 {
   register char **list = *argv;
   register int empty = 1;
@@ -525,7 +499,7 @@ char ***argv, *type;
 /* Make a listing of the super block.  If `repair' is set, ask the user
  * for changes.
  */
-void lsuper()
+void lsuper(void)
 {
   char buf[80];
 
@@ -599,7 +573,7 @@ void rw_super(int put)
 }
 
 /* Check the super block for reasonable contents. */
-void chksuper()
+void chksuper(void)
 {
   register int n;
   register off_t maxsize;
@@ -667,8 +641,7 @@ int inooff(int inn)
 /* Make a listing of the inodes given by `clist'.  If `repair' is set, ask
  * the user for changes.
  */
-void lsi(clist)
-char **clist;
+void lsi(char **clist)
 {
   register bit_nr bit;
   register ino_t ino;
@@ -698,8 +671,7 @@ char **clist;
 }
 
 /* Allocate `nblk' blocks worth of bitmap. */
-bitchunk_t *allocbitmap(nblk)
-int nblk;
+bitchunk_t *allocbitmap(int nblk)
 {
   register bitchunk_t *bitmap;
 
@@ -709,10 +681,7 @@ int nblk;
 }
 
 /* Load the bitmap starting at block `bno' from disk. */
-void loadbitmap(bitmap, bno, nblk)
-bitchunk_t *bitmap;
-block_nr bno;
-int nblk;
+void loadbitmap(bitchunk_t *bitmap, block_nr bno, int nblk)
 {
   register int i;
   register bitchunk_t *p;
@@ -724,10 +693,7 @@ int nblk;
 }
 
 /* Write the bitmap starting at block `bno' to disk. */
-void dumpbitmap(bitmap, bno, nblk)
-bitchunk_t *bitmap;
-block_nr bno;
-int nblk;
+void dumpbitmap(bitchunk_t *bitmap, block_nr bno, int nblk)
 {
   register int i;
   register bitchunk_t *p = bitmap;
@@ -737,10 +703,7 @@ int nblk;
 }
 
 /* Set the bits given by `list' in the bitmap. */
-void fillbitmap(bitmap, lwb, upb, list)
-bitchunk_t *bitmap;
-bit_nr lwb, upb;
-char **list;
+void fillbitmap(bitchunk_t *bitmap, bit_nr lwb, bit_nr upb, char **list)
 {
   register bit_nr bit;
 
@@ -757,14 +720,13 @@ char **list;
 }
 
 /* Deallocate the bitmap `p'. */
-void freebitmap(p)
-bitchunk_t *p;
+void freebitmap(bitchunk_t *p)
 {
   free((char *) p);
 }
 
 /* Get all the bitmaps used by this program. */
-void getbitmaps()
+void getbitmaps(void)
 {
   imap = allocbitmap(N_IMAP);
   zmap = allocbitmap(N_ZMAP);
@@ -774,7 +736,7 @@ void getbitmaps()
 }
 
 /* Release all the space taken by the bitmaps. */
-void putbitmaps()
+void putbitmaps(void)
 {
   freebitmap(imap);
   freebitmap(zmap);
@@ -786,12 +748,7 @@ void putbitmaps()
 /* `w1' and `w2' are differing words from two bitmaps that should be
  * identical.  Print what's the matter with them.
  */
-void chkword(w1, w2, bit, type, n, report, phys)
-unsigned w1, w2;
-char *type;
-bit_nr bit;
-int *n, *report;
-bit_nr phys;
+void chkword(unsigned w1, unsigned w2, bit_nr bit, char *type, int *n, int *report, bit_nr phys)
 {
   for (; (w1 | w2); w1 >>= 1, w2 >>= 1, bit++, phys++)
 	if ((w1 ^ w2) & 1 && ++(*n) % MAXPRINT == 0 && *report &&
@@ -810,12 +767,7 @@ bit_nr phys;
 /* Check if the given (correct) bitmap is identical with the one that is
  * on the disk.  If not, ask if the disk should be repaired.
  */
-void chkmap(cmap, dmap, bit, blkno, nblk, type)
-bitchunk_t *cmap, *dmap;
-bit_nr bit;
-block_nr blkno;
-int nblk;
-char *type;
+void chkmap(bitchunk_t *cmap, bitchunk_t *dmap, bit_nr bit, block_nr blkno, int nblk, char *type)
 {
   register bitchunk_t *p = dmap, *q = cmap;
   int report = 1, nerr = 0;
@@ -841,7 +793,7 @@ char *type;
 }
 
 /* See if the inodes that aren't allocated are cleared. */
-void chkilist()
+void chkilist(void)
 {
   register ino_t ino = 1;
   mode_t mode;
@@ -864,7 +816,7 @@ void chkilist()
 }
 
 /* Allocate an array to maintain the inode reference counts in. */
-void getcount()
+void getcount(void)
 {
   count = (nlink_t *) alloc((unsigned) (sb.s_ninodes + 1), sizeof(nlink_t));
 }
@@ -898,7 +850,7 @@ void counterror(ino_t ino)
  * Thus, when the whole file system has been traversed, all the entries
  * should be zero.
  */
-void chkcount()
+void chkcount(void)
 {
   register ino_t ino;
 
@@ -908,7 +860,7 @@ void chkcount()
 }
 
 /* Deallocate the `count' array. */
-void freecount()
+void freecount(void)
 {
   free((char *) count);
 }
@@ -983,10 +935,7 @@ int Remove(dir_struct *dp)
 }
 
 /* Convert string so that embedded control characters are printable. */
-void make_printable_name(dst, src, n)
-register char *dst;
-register char *src;
-register int n;
+void make_printable_name(register char *dst, register char *src, register int n)
 {
   register int c;
 
@@ -1194,11 +1143,7 @@ int chksymlinkzone(ino_t ino, d_inode *ip, off_t pos, zone_nr zno)
 }
 
 /* There is something wrong with the given zone.  Print some details. */
-void errzone(mess, zno, level, pos)
-char *mess;
-zone_nr zno;
-int level;
-off_t pos;
+void errzone(char *mess, zone_nr zno, int level, off_t pos)
 {
   printf("%s zone in ", mess);
   printpath(1, 0);
@@ -1215,10 +1160,7 @@ off_t pos;
 /* Found the given zone in the given inode.  Check it, and if ok, mark it
  * in the zone bitmap.
  */
-int markzone(zno, level, pos)
-zone_nr zno;
-int level;
-off_t pos;
+int markzone(zone_nr zno, int level, off_t pos)
 {
   register bit_nr bit = (bit_nr) zno - FIRST + 1;
 
@@ -1259,8 +1201,7 @@ int chkindzone(ino_t ino, d_inode *ip, off_t *pos, zone_nr zno, int level)
 /* Return the size of a gap in the file, represented by a null zone number
  * at some level of indirection.
  */
-off_t jump(level)
-int level;
+off_t jump(int level)
 {
   off_t power = ZONE_SIZE;
 
@@ -1451,8 +1392,7 @@ int chkinode(ino_t ino, d_inode *ip)
 }
 
 /* Check the directory entry pointed to by dp, by checking the inode. */
-int descendtree(dp)
-dir_struct *dp;
+int descendtree(dir_struct *dp)
 {
   d_inode inode;
   register ino_t ino = dp->d_inum;
@@ -1488,7 +1428,7 @@ dir_struct *dp;
 }
 
 /* Check the file system tree. */
-void chktree()
+void chktree(void)
 {
   dir_struct dir;
 
@@ -1501,7 +1441,7 @@ void chktree()
 }
 
 /* Print the totals of all the objects found. */
-void printtotal()
+void printtotal(void)
 {
   if(preen) {
   	printf("%d files, %d directories, %d free inodes, %ld free zones\n",
@@ -1535,8 +1475,7 @@ void printtotal()
  * listed by `zlist' should be watched for while checking the file system.
  */
 
-void chkdev(f, clist, ilist, zlist)
-char *f, **clist, **ilist, **zlist;
+void chkdev(char *f, char **clist, char **ilist, char **zlist)
 {
   if (automatic) repair = 1;
   fsck_device = f;
@@ -1613,9 +1552,7 @@ char *f, **clist, **ilist, **zlist;
   devclose();
 }
 
-int main(argc, argv)
-int argc;
-char **argv;
+int main(int argc, char **argv)
 {
   register char **clist = 0, **ilist = 0, **zlist = 0;
   int badflag = 0;

--- a/minix/commands/ifdef/ifdef.c
+++ b/minix/commands/ifdef/ifdef.c
@@ -66,13 +66,11 @@ void gettable(void);
 void parse(void);
 void usage(void);
 
-#ifdef __STDC__
+
+/* Get next arg from file into cbuf, */
+/* returning the character that      */
+/* terminated it. Cbuf returns 0     */
 char fgetarg ( FILE *stream , char *cbuf )
-#else
-char fgetarg(stream, cbuf)	/* Get next arg from file into cbuf, */
-FILE *stream;			/* returning the character that      */
-char *cbuf;			/* terminated it. Cbuf returns 0     */
-#endif
 {				/* if no arg. EOF is returned if no  */
   int ch;			/* args left in file.                */
   int i;
@@ -95,12 +93,7 @@ char *cbuf;			/* terminated it. Cbuf returns 0     */
 }
 
 
-#ifdef __STDC__
 int find ( char *sym )
-#else
-int find(sym)
-char *sym;
-#endif
 {				/* Return DEF if defined else UNDEF */
 
   deftemp = defptr;
@@ -118,14 +111,10 @@ char *sym;
 #define Undefine(x,y)	defit(x,y,UNDEF)
 #define Ignore(x,y)	defit(x,y,IGN)
 
-#ifdef __STDC__
+/* Add symbol to the define list */
+/* Mode: MUTABLE etc      */
+/* Type: DEF, UNDEF, IGN  */
 void defit ( char *sym , int redef , int type )
-#else
-void defit(sym, redef, type)	/* Add symbol to the define list */
-char *sym;
-char redef;			/* Mode: MUTABLE etc      */
-char type;			/* Type: DEF, UNDEF, IGN  */
-#endif
 {
   struct DEFINE *temp;
   char c;
@@ -167,11 +156,7 @@ char type;			/* Type: DEF, UNDEF, IGN  */
 
 
 
-#ifdef __STDC__
 void stop ( void )
-#else
-void stop()
-#endif
 {				/* Stop: Tidy up at EOF */
   if (table) printtable();
   (void)fclose(zin);
@@ -181,23 +166,16 @@ void stop()
 #define Goto	{ line++; if (ch!='\n') gotoeoln(); }
 #define Print	{ line++; if (ch!='\n') prteoln();  }
 
-#ifdef __STDC__
+/* Go to the end of the line */
 void gotoeoln ( void )
-#else
-void gotoeoln()			/* Go to the end of the line */
-#endif
 {
   int ch;
   while ((ch = fgetc(zin)) != '\n')
 	if (ch == EOF) stop();
 }
 
-
-#ifdef __STDC__
+/* Print to the end of the line */
 void prteoln ( void )
-#else
-void prteoln()			/* Print to the end of the line */
-#endif
 {
   int ch;
   while ((ch = fgetc(zin)) != '\n')
@@ -209,11 +187,8 @@ void prteoln()			/* Print to the end of the line */
 }
 
 
-#ifdef __STDC__
+/* Print the defines in the SLL */
 void printtable ( void )
-#else
-void printtable()		/* Print the defines in the SLL */
-#endif
 {
   struct DEFINE *temp;
 
@@ -234,11 +209,7 @@ void printtable()		/* Print the defines in the SLL */
   }
 }
 
-#ifdef __STDC__
 char getendif ( void )
-#else
-char getendif()
-#endif
 {				/* Find matching endif when ignoring */
   char word[80];		/* Buffer for symbols */
   int ch;
@@ -268,11 +239,8 @@ char getendif()
 }
 
 
-#ifdef __STDC__
+/* Get & print a table of defines etc.  */
 void gettable ( void )
-#else
-void gettable()			/* Get & print a table of defines etc.  */
-#endif
 {
 
   char word[80];		/* Buffer for symbols */
@@ -313,11 +281,7 @@ void gettable()			/* Get & print a table of defines etc.  */
 
 
 
-#ifdef __STDC__
 void parse ( void )
-#else
-void parse()
-#endif
 {				/* Parse & remove ifdefs from C source */
   char word[80];		/* Buffer for symbols */
   int ch;
@@ -435,24 +399,14 @@ void parse()
 }
 
 
-#ifdef __STDC__
 void usage ( void )
-#else
-void usage()
-#endif
 {
   (void)fprintf(stderr, "Usage: ifdef [-t] [-Dsymbol] [-dsymbol] [-Usymbol] [-Isymbol] <file>\n");
   exit(0);
 }
 
 
-#ifdef __STDC__
 int main(int argc , char *argv [])
-#else
-int main(argc, argv)
-int argc;
-char *argv[];
-#endif
 {
   char sym[80];			/* Temp symbol storage */
   int c;

--- a/minix/commands/isoread/isoread.c
+++ b/minix/commands/isoread/isoread.c
@@ -184,10 +184,7 @@ int Verbose = 0;        /* 1 = Print all info on directories */
 int ByteOffset = 0;     /* 1 = Print byte offset and length of files */
 int Aflag = 0;          /* 1 = Suppress output of \r  */
 
-int iso_cmp(name, dir_ptr, dir_flag)
-char *name;
-struct dir_entry *dir_ptr;
-int dir_flag;
+int iso_cmp(char *name, struct dir_entry *dir_ptr, int dir_flag)
 {
 /* Compare name with directory entries, looking for match with a dirname.
  * An iso9660 filename is terminated by ";n", where n will probably 
@@ -215,7 +212,7 @@ int dir_flag;
 }
 
 
-void usage()
+void usage(void)
 {
   if (Read_Dir)
    fprintf (STDERR, "Usage: isodir [-lrB] inputfile [dir]\n");
@@ -227,9 +224,7 @@ void usage()
 }
 
 
-int main(argc, argv)
-int argc;
-char **argv;
+int main(int argc, char **argv)
 {
   struct dir_entry *entry;
   char path[MAX_PATH_LENGTH];
@@ -352,8 +347,7 @@ char **argv;
 }
 
 
-struct dir_entry *look_up(path)
-char *path;
+struct dir_entry *look_up(char *path)
 {
   /* Lookup a file name */
 
@@ -428,9 +422,7 @@ char *path;
 }
   
 
-void recurse_dir(path, dir_ptr)
-char *path;
-struct dir_entry *dir_ptr;
+void recurse_dir(char *path, struct dir_entry *dir_ptr)
 {
   /* Recursively descend all directories starting with dir_ptr */
 
@@ -503,8 +495,7 @@ struct dir_entry *dir_ptr;
 }
     
 
-void list_dir(dir_ptr)
-struct dir_entry *dir_ptr;
+void list_dir(struct dir_entry *dir_ptr)
 {
   /* List all entries in a directory */
   int tty;
@@ -601,8 +592,7 @@ struct dir_entry *dir_ptr;
 }
 
 
-void print_dir_date(date)
-char *date;
+void print_dir_date(char *date)
 {
   /* Print date in a directory entry */
 
@@ -623,8 +613,7 @@ char *date;
 }
 
 
-void list_file(dir_ptr)
-struct dir_entry *dir_ptr;
+void list_file(struct dir_entry *dir_ptr)
 {
   /* List contents of a file */
 
@@ -658,8 +647,7 @@ struct dir_entry *dir_ptr;
 }
 
 
-void print_date(date)
-char *date;
+void print_date(char *date)
 {
   /* Print the date in a volume descriptor */
 
@@ -680,8 +668,7 @@ char *date;
            date[13]);
 }
 
-void iso_info(vol_desc)
-struct iso9660_descriptor *vol_desc;
+void iso_info(struct iso9660_descriptor *vol_desc)
 {
   int i;
 
@@ -711,8 +698,7 @@ struct iso9660_descriptor *vol_desc;
 }
 
 
-void hs_info(vol_desc)
-struct high_sierra_descriptor *vol_desc;
+void hs_info(struct high_sierra_descriptor *vol_desc)
 {
   int i;
 
@@ -730,7 +716,7 @@ struct high_sierra_descriptor *vol_desc;
 }
   
 
-int valid_fs()               
+int valid_fs(void) 
 {
 
   int i;
@@ -764,10 +750,7 @@ int valid_fs()
 }
 
 
-void read_device(offset, nr_of_bytes, buffer)
-long offset;
-int nr_of_bytes;
-char *buffer;
+void read_device(long offset, int nr_of_bytes, char *buffer)
 {
   int bytes_read;
 
@@ -790,15 +773,13 @@ char *buffer;
 
 /* The ISO9660 functions */
 
-int iso_711 (c)
-char *c;
+int iso_711 (char *c)
 {
   return (*c & 0xff);
 }
 
 
-int iso_712 (c)
-char *c;
+int iso_712 (char *c)
 {
   int n;
 	
@@ -807,20 +788,17 @@ char *c;
   return n;
 }
 
-int iso_721 (c)
-char *c;
+int iso_721 (char *c)
 {
   return ((c[0] & 0xff) | ((c[1] & 0xff) << 8));
 }
 
-int iso_722 (c)
-char *c;
+int iso_722 (char *c)
 {
   return (((c[0] & 0xff) << 8) | (c[1] & 0xff));
 }
 
-int iso_723 (c)
-char *c;
+int iso_723 (char *c)
 {
   if (c[0] != c[3] || c[1] != c[2]) 
   {
@@ -830,8 +808,7 @@ char *c;
   return (iso_721 (c));
 }
 
-long iso_731 (c)
-char *c;
+long iso_731 (char *c)
 {
   return ((long)(c[0] & 0xff)
        | ((long)(c[1] & 0xff) << 8)
@@ -840,8 +817,7 @@ char *c;
 }
 
 
-long iso_732 (c)
-char *c;
+long iso_732 (char *c)
 {
   return (((long)(c[0] & 0xff) << 24)
         | (((long)c[1] & 0xff) << 16)
@@ -849,8 +825,7 @@ char *c;
         | ((long)c[3] & 0xff));
 }
 
-long iso_733 (c)
-char *c;
+long iso_733 (char *c)
 {
 int i;
 

--- a/minix/commands/mail/mail.c
+++ b/minix/commands/mail/mail.c
@@ -91,9 +91,7 @@ char *whoami(void);
 void dohelp(void);
 int filesize(char *name);
 
-int main(argc, argv)
-int argc;
-char *argv[];
+int main(int argc, char *argv[])
 {
   int c;
 
@@ -161,9 +159,7 @@ char *argv[];
   return(0);
 }
 
-int deliver(count, vec)
-int count;
-char *vec[];
+int deliver(int count, char *vec[])
 {
   int i, j;
   int errs = 0;			/* count of errors */
@@ -343,7 +339,7 @@ nobox:
  * for interactive mails, this might be the place to do it (though the
  * case where a MAILER is being used would also need to be handled).
  */
-FILE *makerewindable()
+FILE *makerewindable(void)
 {
   FILE *tempfp;			/* temp file used for copy */
   int c;			/* character being copied */
@@ -387,8 +383,7 @@ done:
   return tempfp;
 }
 
-int copy(fromfp, tofp)
-FILE *fromfp, *tofp;
+int copy(FILE *fromfp, FILE *tofp)
 {
   int c;			/* character being copied */
   int state;			/* ".\n" and postmark detection state */
@@ -455,7 +450,7 @@ done:
   return 0;
 }
 
-void readbox()
+void readbox(void)
 {
   char linebuf[512];
   struct letter *let;
@@ -496,7 +491,7 @@ void readbox()
   }
 }
 
-void printall()
+void printall(void)
 {
   struct letter *let;
 
@@ -512,7 +507,7 @@ void printall()
   }
 }
 
-void interact()
+void interact(void)
 {
   char linebuf[512];		/* user input line */
   struct letter *let, *next;	/* current and next letter */
@@ -592,15 +587,13 @@ void interact()
   }
 }
 
-void onint(dummy)
-int dummy;	/* to satisfy ANSI compilers */
+/* dummy to satisfy ANSI compilers */
+void onint(int dummy)
 {
   longjmp(printjump, 1);
 }
 
-void savelet(let, savefile)
-struct letter *let;
-char *savefile;
+void savelet(struct letter *let, char *savefile)
 {
   int waitstat, pid;
   FILE *savefp;
@@ -628,7 +621,7 @@ char *savefile;
   exit(0);
 }
 
-void updatebox()
+void updatebox(void)
 {
   FILE *tempfp;			/* fp for tempfile */
   char lockname[PATHLEN];	/* maildrop lock */
@@ -683,9 +676,7 @@ void updatebox()
   if (usedrop) unlink(lockname);
 }
 
-void printlet(let, tofp)
-struct letter *let;
-FILE *tofp;
+void printlet(struct letter *let, FILE *tofp)
 {
   off_t current, limit;
   int c;
@@ -699,8 +690,7 @@ FILE *tofp;
   }
 }
 
-void doshell(command)
-char *command;
+void doshell(char *command)
 {
   int waitstat, pid;
   char *shell;
@@ -725,14 +715,13 @@ char *command;
   exit(127);
 }
 
-void usage()
+void usage(void)
 {
   fprintf(stderr, "usage: mail [-epqr] [-f file]\n");
   fprintf(stderr, "       mail [-dtv] [-s subject] user [...]\n");
 }
 
-char *basename(name)
-char *name;
+char *basename(char *name)
 {
   char *p;
 
@@ -742,7 +731,7 @@ char *name;
 	return p + 1;
 }
 
-char *whoami()
+char *whoami(void)
 {
   struct passwd *pw;
 
@@ -752,7 +741,7 @@ char *whoami()
 	return "nobody";
 }
 
-void dohelp()
+void dohelp(void)
 {
   FILE *fp;
   char buffer[80];
@@ -768,8 +757,7 @@ void dohelp()
   fclose(fp);
 }
 
-int filesize(name)
-char *name ;
+int filesize(char *name)
 {
   struct stat buf;
  

--- a/minix/commands/mount/mount.c
+++ b/minix/commands/mount/mount.c
@@ -20,9 +20,7 @@ int mount_all(void);
 
 static int write_mtab = 1;
 
-int main(argc, argv)
-int argc;
-char *argv[];
+int main(int argc, char *argv[])
 {
   int all = 0, i, v = 0, mountflags, srvflags;
   char **ap, *opt, *err, *type, *args, *device;
@@ -88,7 +86,7 @@ char *argv[];
   return(EXIT_SUCCESS);
 }
 
-void list()
+void list(void)
 {
   int n;
   char dev[PATH_MAX], mountpoint[PATH_MAX], type[MNTNAMELEN], flags[MNTFLAGLEN];
@@ -121,7 +119,7 @@ has_opt(char *mntopts, char *option)
 
 
 int
-mount_all()
+mount_all(void)
 {
 	struct fstab *fs;
 	int ro, mountflags;
@@ -165,7 +163,7 @@ mount_all()
 	return(EXIT_SUCCESS);
 }
 
-void usage()
+void usage(void)
 {
   std_err("Usage: mount [-a] [-r] [-e] [-t type] [-o options] special name\n");
   exit(1);

--- a/minix/commands/playwave/playwave.c
+++ b/minix/commands/playwave/playwave.c
@@ -60,7 +60,7 @@ DWORD data_len;
 /******** End of wave definitions *********/
 
 
-void usage()
+void usage(void)
 {
   fprintf(stderr, "Usage: playwav [-i] file\n");
   exit(-1);

--- a/minix/commands/prep/prep.c
+++ b/minix/commands/prep/prep.c
@@ -17,9 +17,7 @@ void skipline(void);
 int backslash(void);
 void usage(void);
 
-int main(argc, argv)
-int argc;
-char *argv[];
+int main(int argc, char *argv[])
 {
 
   int c;
@@ -66,7 +64,7 @@ char *argv[];
 }
 
 
-void skipline()
+void skipline(void)
 {
   char c;
 
@@ -74,7 +72,7 @@ void skipline()
 }
 
 
-int backslash()
+int backslash(void)
 {
 /* A backslash has been seen.  Eat troff stuff. */
 
@@ -129,7 +127,7 @@ int backslash()
   }
 }
 
-void usage()
+void usage(void)
 {
   printf("Usage: prep [file]\n");
   exit(1);

--- a/minix/commands/printroot/printroot.c
+++ b/minix/commands/printroot/printroot.c
@@ -31,9 +31,7 @@ int rflag;
 int main(int argc, char **argv);
 void done(char *name, int status);
 
-int main(argc, argv)
-int argc;
-char **argv;
+int main(int argc, char **argv)
 {
   DIR *dp;
   struct dirent *entry;
@@ -56,9 +54,7 @@ char **argv;
   return(0);			/* not reached */
 }
 
-void done(name, status)
-char *name;
-int status;
+void done(char *name, int status)
 {
   int v;
 

--- a/minix/commands/profile/profile.c
+++ b/minix/commands/profile/profile.c
@@ -196,7 +196,7 @@ int handle_args(int argc, char *argv[])
 }
 
 
-int start()
+int start(void)
 {
  /* This is the "starter process" for statistical profiling.
   *
@@ -262,7 +262,7 @@ int start()
 }
 
 
-int stop()
+int stop(void)
 {
   /* This is the "stopper" process for statistical profiling.
    *
@@ -296,7 +296,7 @@ int stop()
 }
 
 
-int alloc_mem()
+int alloc_mem(void)
 {
   if ((mem_ptr = malloc(mem_size)) == 0) {
 	fprintf(stderr, "Unable to allocate memory.\n");
@@ -308,7 +308,7 @@ int alloc_mem()
 }
 
 
-int init_outfile()
+int init_outfile(void)
 {
   if ((outfile_fd = open(outfile, O_CREAT | O_TRUNC | O_WRONLY)) <= 0) {
 	fprintf(stderr, "Unable to create outfile %s.\n", outfile);

--- a/minix/commands/progressbar/progressbar.c
+++ b/minix/commands/progressbar/progressbar.c
@@ -44,9 +44,7 @@ prettyprogress(long b, long maxb, time_t starttime)
   return;
 }
 
-int main(argc, argv)
-int argc;
-char *argv[];
+int main(int argc, char *argv[])
 {
 	long i = 0, count = 0;
 	int l;

--- a/minix/commands/recwave/recwave.c
+++ b/minix/commands/recwave/recwave.c
@@ -74,7 +74,7 @@ int old_stdin;
 struct termios old_tty, new_tty;
 int audio, file;
 
-void usage()
+void usage(void)
 {
   fprintf(stderr, "Usage: recwav [-b -s -r] file_name\n");
   exit(-1);
@@ -90,7 +90,7 @@ void terminate(int s)
   exit(0);		
 }
 
-void write_wave_header()
+void write_wave_header(void)
 {
   /* RIFF fields */
   r_fields.RIFF_id = RIFF_ID;

--- a/minix/commands/svrctl/svrctl.c
+++ b/minix/commands/svrctl/svrctl.c
@@ -104,7 +104,7 @@ int main (int argc, char *argv[])
   return(EXIT_FAILURE);
 }
 
-static void usage()
+static void usage(void)
 {
   fprintf(stderr, "Usage:\n");
   fprintf(stderr, "  %s <vfs|pm> set <request> <value>\n", bin_name);

--- a/minix/commands/swifi/db_access.c
+++ b/minix/commands/swifi/db_access.c
@@ -46,10 +46,7 @@ static unsigned db_extend[] = {	/* table for sign-extending */
 };
 
 void
-db_read_bytes(addr, size, data)
-	vm_offset_t	addr;
-	register int	size;
-	register char	*data;
+db_read_bytes(vm_offset_t addr, register int size, register char *data)
 {
 	register char	*src;
 
@@ -60,10 +57,7 @@ db_read_bytes(addr, size, data)
 }
 
 db_expr_t
-db_get_value(addr, size, is_signed)
-	db_addr_t	addr;
-	register int	size;
-	boolean_t	is_signed;
+db_get_value(db_addr_t addr, register int size, boolean_t is_signed)
 {
 	char		data[sizeof(int)];
 	register db_expr_t value;

--- a/minix/commands/swifi/db_disasm.c
+++ b/minix/commands/swifi/db_disasm.c
@@ -866,11 +866,7 @@ static db_addr_t
  * Read address at location and return updated location.
  */
 static db_addr_t
-db_read_address(loc, short_addr, regmodrm, addrp)
-	db_addr_t	loc;
-	int		short_addr;
-	int		regmodrm;
-	struct i_addr *	addrp;		/* out */
+db_read_address(db_addr_t loc, int short_addr, int regmodrm, struct i_addr *addrp /* out */)
 {
 	int		mod, rm, sib, index, disp;
 

--- a/minix/commands/swifi/extra.c
+++ b/minix/commands/swifi/extra.c
@@ -137,10 +137,7 @@ void text_write_ub(void *addr, unsigned char value)
 	}
 }
 
-void load_nlist(exe_name, btextp, etextp)
-char *exe_name;
-unsigned long *btextp;
-unsigned long *etextp;
+void load_nlist(char *exe_name, unsigned long *btextp, unsigned long *etextp)
 {
 	int i;
 	unsigned long btext, etext;

--- a/minix/commands/synctree/synctree.c
+++ b/minix/commands/synctree/synctree.c
@@ -126,7 +126,7 @@ struct mode {
 static char *arg0;	/* basename(argv[0]) */
 static int ex= 0;	/* exit status. */
 
-static void because()
+static void because(void)
 {
 	fprintf(stderr, ": %s\n", strerror(errno));
 	ex= 1;
@@ -255,7 +255,7 @@ static void sort(struct entry **ae)
 	}
 }
 
-static void enter()
+static void enter(void)
 /* Collect directory entries of E. */
 {
 	struct entry **last= &E->con, *new;
@@ -399,7 +399,7 @@ static char *link_islink(struct stat *stp, const char *file)
 
 #define cancellink()	((void) islink())
 
-static char *islink()
+static char *islink(void)
 /* Returns the name of the file path is linked to.  If no such link can be
  * found, then path is added to the list and nil is returned.  If all the
  * links of a file have been seen, then it is removed from the list.
@@ -464,7 +464,7 @@ static int getstat(char *name, struct stat *stp)
 	return 0;
 }
 
-static int advance()
+static int advance(void)
 /* Determine next pathname, return true on success. */
 {
 	for (;;) {
@@ -517,7 +517,7 @@ static int advance()
 	return 1;
 }
 
-static enum orders request()
+static enum orders request(void)
 /* Slave reads command sent by master. */
 {
 	static char buf[64], *bp;
@@ -547,7 +547,7 @@ static enum orders request()
 	return (enum orders) req;
 }
 
-static void report()
+static void report(void)
 {
 	int r;
 
@@ -614,7 +614,7 @@ static void sendstat(struct stat *stp)
 
 static int ask();
 
-static void slave()
+static void slave(void)
 /* Carry out orders from the master, such as transmitting path names.
  * Note that the slave uses path, not Spath, the master uses Spath.
  */
@@ -763,7 +763,7 @@ static void rread(char *buf, int n)
 	}
 }
 
-static enum answers answer()
+static enum answers answer(void)
 /* Master reads slave's reply. */
 {
 	char c;
@@ -777,7 +777,7 @@ static enum answers answer()
 	return (enum answers) a;
 }
 
-static long recnum()
+static long recnum(void)
 /* Read number as pack of bytes from least to most significant.  The data
  * is on the wire in little-endian format.  (Mostly run on PC's).
  */
@@ -822,7 +822,7 @@ static void recstat(struct stat *stp)
 	stp->st_mtime= recnum();
 }
 
-static int key()
+static int key(void)
 {
 	int c;
 	static int tty= -1;
@@ -1105,7 +1105,7 @@ static int delete(int update)
 	return 1;
 }
 
-static int different()
+static int different(void)
 /* Return true iff path and Spath are different. */
 {
 	if (! ( (linkpath == nil && Slinkpath == nil)
@@ -1136,7 +1136,7 @@ static int different()
 	}
 }
 
-static void compare()
+static void compare(void)
 /* See if path and Spath are same. */
 {
 	if (different()) {
@@ -1158,7 +1158,7 @@ static void compare()
 
 static int done= 0, Sdone= 0;
 
-static enum action { ADD, COMPARE, DELETE } action()
+static enum action { ADD, COMPARE, DELETE } action(void)
 /* Look at path's of master and slave, compare them alphabetically to see
  * who is ahead of who, then tell what is to be done.
  */
@@ -1178,7 +1178,7 @@ static enum action { ADD, COMPARE, DELETE } action()
 	return (c= strcmp(Sp, p)) == 0 ? COMPARE : c < 0 ? ADD : DELETE;
 }
 
-static void master()
+static void master(void)
 /* Synchronise file tree to that of its slave. */
 {
 	enum action a= COMPARE;	/* Trick first advances. */
@@ -1244,7 +1244,7 @@ static void master()
 	order(ex == 0 ? DIE : DIE_BAD);
 }
 
-static void mediator()
+static void mediator(void)
 /* Sits at the local machine and passes orders from master to slave, both
  * on remote machines.  Only diagnostics and questions are handled.
  */
@@ -1346,7 +1346,7 @@ void splitcolon(char *path, char **amach, char **adir)
 	}
 }
 
-static void Usage()
+static void Usage(void)
 {
 	fprintf(stderr,
 	    "Usage: %s [-iuf] [[user@]machine:]dir1 [[user@]machine:]dir2\n",

--- a/minix/commands/term/term.c
+++ b/minix/commands/term/term.c
@@ -125,9 +125,7 @@ void set_uart(int argc, char *argv[], struct termios *tcp);
 void set_raw(struct termios *tcp);
 void quit(int code);
 
-int main(argc, argv)
-int argc;
-char *argv[];
+int main(int argc, char *argv[])
 {
   int i;
   unsigned char key;
@@ -298,8 +296,7 @@ void tell(int fd, ...)
 }
 
 
-void reader(on)
-int on;
+void reader(int on)
 {
 /* Start or end a process that copies from the modem to the screen. */
 
@@ -390,8 +387,7 @@ void shell(char *cmd)
 }
 
 
-void lock_device(device)
-char *device;
+void lock_device(char *device)
 {
 /* Lock a device by creating a lock file using SYSV style locking. */
 
@@ -473,10 +469,7 @@ void setnum(char *s, int n)
 }
 
 
-void set_uart(argc, argv, tcp)
-int argc;
-char *argv[];
-struct termios *tcp;
+void set_uart(int argc, char *argv[], struct termios *tcp)
 {
 /* Set up the UART parameters. */
 
@@ -515,8 +508,7 @@ struct termios *tcp;
 }
 
 
-void set_raw(tcp)
-struct termios *tcp;
+void set_raw(struct termios *tcp)
 {
   /* Set termios attributes for RAW mode. */
 
@@ -528,8 +520,7 @@ struct termios *tcp;
 }
 
 
-void quit(code)
-int code;
+void quit(int code)
 {
 /* Stop the reader process, reset the terminal, and exit. */
   reader(0);

--- a/minix/commands/termcap/termcap.c
+++ b/minix/commands/termcap/termcap.c
@@ -20,9 +20,7 @@ int main(int argc, char **argv);
 void Print(char *comment, char *name);
 void Error(char *message, char *arg);
 
-int main(argc, argv)
-int argc;
-char *argv[];
+int main(int argc, char **argv)
 
   {
   char *term;
@@ -154,9 +152,7 @@ void Print( comment, name )
 /****************************************************************/
 
 
-void Error( message, arg )
-  char *message;
-  char *arg;
+void Error( char *message, char *arg )
 
   {
   fprintf( stderr, message, arg );

--- a/minix/commands/umount/umount.c
+++ b/minix/commands/umount/umount.c
@@ -22,9 +22,7 @@ void usage(void);
 static char device[PATH_MAX], mount_point[PATH_MAX], type[MNTNAMELEN],
 		flags[MNTFLAGLEN];
 
-int main(argc, argv)
-int argc;
-char *argv[];
+int main(int argc, char *argv[])
 {
   int found;
   int umount_flags = 0UL;
@@ -62,8 +60,7 @@ char *argv[];
   return(0);
 }
 
-int find_mtab_entry(name)
-char *name;
+int find_mtab_entry(char *name)
 {
 /* Find a matching mtab entry for 'name' which may be a special or a path,
  * and generate a new mtab file without this entry on the fly. Do not write
@@ -97,7 +94,7 @@ char *name;
   return found;
 }
 
-void usage()
+void usage(void)
 {
   std_err("Usage: umount [-e] name\n");
   exit(1);

--- a/minix/commands/update/update.c
+++ b/minix/commands/update/update.c
@@ -6,7 +6,7 @@
 
 int main(void);
 
-int main()
+int main(void)
 {
   /* Release all (?) open file descriptors. */
   close(0);

--- a/minix/commands/vol/vol.c
+++ b/minix/commands/vol/vol.c
@@ -58,9 +58,7 @@ void tape_inquire(char *name, int fd);
 void allocate_buffer(void);
 void diskio(int fd1, int fd2, char *file1, char *file2);
 
-int main(argc, argv)
-int argc;
-char *argv[];
+int main(int argc, char *argv[])
 {
   int volume = 1, fd, tty, i, init, autovolsize;
   char *p, *name;
@@ -208,18 +206,14 @@ char *argv[];
   }
 }
 
-void usage()
+void usage(void)
 {
   fprintf(stderr,
 	"Usage: vol [-rw1] [-b blocksize] [-m max] [size] block-special\n");
   exit(1);
 }
 
-long str2size(name, str, min, max, assume_kb)
-char *name;
-char *str;
-long min, max;
-int assume_kb;
+long str2size(char *name, char *str, long min, long max, int assume_kb)
 {
   /* Convert a string to a size.  The number may be followed by 'm', 'k', 'b'
    * or 'w' to multiply the size as shown below.  If 'assume_kb' is set then
@@ -259,9 +253,7 @@ int assume_kb;
   return size;
 }
 
-void tape_inquire(name, fd)
-char *name;
-int fd;
+void tape_inquire(char *name, int fd)
 {
   /* If the device happens to be a tape, then what is its block size? */
   struct mtget mtget;
@@ -288,7 +280,7 @@ int fd;
   }
 }
 
-void allocate_buffer()
+void allocate_buffer(void)
 {
   /* Set block size and maximum multiple. */
   if (block_size == 0) block_size = variable ? 1 : FIX_BLKSIZ;
@@ -313,9 +305,7 @@ void allocate_buffer()
   }
 }
 
-void diskio(fd1, fd2, file1, file2)
-int fd1, fd2;
-char *file1, *file2;
+void diskio(int fd1, int fd2, char *file1, char *file2)
 {
 /* Read 'volume_size' bytes from 'fd1' and write them on 'fd2'.  Watch out for
  * the fact that reads on pipes can return less than the desired data.

--- a/minix/commands/zmodem/rbsb.c
+++ b/minix/commands/zmodem/rbsb.c
@@ -62,7 +62,7 @@ Howmany must be 255 or less
  */
 int Fromcu;		/* Were called from cu or yam */
 
-void from_cu()
+void from_cu(void)
 {
 	struct stat a, b;
 
@@ -71,7 +71,7 @@ void from_cu()
 	return;
 }
 
-void cucheck()
+void cucheck(void)
 {
 	if (Fromcu)
 		fprintf(stderr,"Please read the manual page BUGS chapter!\r\n");
@@ -123,7 +123,7 @@ char checked = '\0' ;
 /*
  * Nonblocking I/O is a bit different in System V, Release 2
  */
-int rdchk(f)
+int rdchk(int f)
 {
 	int lf, savestat;
 
@@ -170,8 +170,7 @@ int iofd = 0;		/* File descriptor for ioctls & reads */
  *  1: save old tty stat, set raw mode 
  *  0: restore original tty mode
  */
-int mode(n)
-int n;
+int mode(int n)
 {
 	static int did0 = FALSE;
 
@@ -397,7 +396,7 @@ int n;
 	}
 }
 
-void sendbrk()
+void sendbrk(void)
 {
 #ifdef POSIX
 	tcsendbreak(iofd, 1);

--- a/minix/commands/zmodem/rz.c
+++ b/minix/commands/zmodem/rz.c
@@ -178,7 +178,7 @@ FILE *fout;
  * Routine to calculate the free bytes on the current file system
  *  ~0 means many free bytes (unknown)
  */
-long getfree()
+long getfree(void)
 {
 	return(~0L);	/* many free bytes ... */
 }
@@ -240,8 +240,7 @@ jmp_buf tohere;		/* For the interrupt on RX timeout */
 
 int tryzhdrtype=ZRINIT;	/* Header type to send corresponding to Last rx close */
 
-void alrm(sig)
-int sig;
+void alrm(int sig)
 {
 	longjmp(tohere, -1);
 }
@@ -373,7 +372,7 @@ int main(int argc, char *argv[])
 }
 
 
-int usage()
+int usage(void)
 {
 	cucheck();
 #ifdef vax11c
@@ -513,7 +512,7 @@ et_tu:
  * Jack M. Wierda and Roderick W. Hart
  */
 
-int wcrx()
+int wcrx(void)
 {
 	register int sectnum, sectcurr;
 	register char sendchar;
@@ -711,7 +710,7 @@ int readline(int timeout)
 /*
  * Purge the modem input queue of all characters
  */
-void purgeline()
+void purgeline(void)
 {
 	Lleft = 0;
 #ifdef USG
@@ -1032,7 +1031,7 @@ void zperr(char *s, char *p, char *u)
 }
 
 /* send cancel string to get the other end to shut up */
-void canit()
+void canit(void)
 {
 	static char canistr[] = {
 	 24,24,24,24,24,24,24,24,24,24,8,8,8,8,8,8,8,8,8,8,0
@@ -1113,7 +1112,7 @@ void checkpath(char *name)
  *  Return ZFILE if Zmodem filename received, -1 on error,
  *   ZCOMPL if transaction finished,  else 0
  */
-int tryz()
+int tryz(void)
 {
 	register int c, n;
 	register int cmdzack1flg;
@@ -1209,7 +1208,7 @@ again:
 /*
  * Receive 1 or more files with ZMODEM protocol
  */
-int rzfiles()
+int rzfiles(void)
 {
 	register int c;
 
@@ -1238,7 +1237,7 @@ int rzfiles()
  * Receive a file with ZMODEM protocol
  *  Assumes file name frame is in secbuf
  */
-int rzfile()
+int rzfile(void)
 {
 	register int c, n;
 	long rxbytes;
@@ -1437,7 +1436,7 @@ void zmputs(char *s)
 /*
  * Close the receive dataset, return OK or ERROR
  */
-int closeit()
+int closeit(void)
 {
 	time_t q;
 
@@ -1468,7 +1467,7 @@ int closeit()
 /*
  * Ack a ZFIN packet, let byegones be byegones
  */
-void ackbibi()
+void ackbibi(void)
 {
 	register int n;
 

--- a/minix/commands/zmodem/sz.c
+++ b/minix/commands/zmodem/sz.c
@@ -652,7 +652,7 @@ int wctxpn(char *name)
 	return OK;
 }
 
-int getnak()
+int getnak(void)
 {
 	register int firstch;
 
@@ -850,7 +850,7 @@ int filbuf(char *buf, int count)
 }
 
 /* Fill buffer with blklen chars */
-int zfilbuf()
+int zfilbuf(void)
 {
 	int n;
 
@@ -984,13 +984,13 @@ int readline(int timeout)
 	return (byt[0]&0377);
 }
 
-void flushmo()
+void flushmo(void)
 {
 	fflush(stdout);
 }
 
 
-void purgeline()
+void purgeline(void)
 {
 #ifdef USG
 	ioctl(iofd, TCFLSH, 0);
@@ -1001,7 +1001,7 @@ void purgeline()
 #endif
 
 /* send cancel string to get the other end to shut up */
-void canit()
+void canit(void)
 {
 	static char canistr[] = {
 	 24,24,24,24,24,24,24,24,24,24,8,8,8,8,8,8,8,8,8,8,0
@@ -1099,7 +1099,7 @@ char *babble[] = {
 	""
 };
 
-int usage()
+int usage(void)
 {
 	char **pp;
 
@@ -1115,7 +1115,7 @@ int usage()
 /*
  * Get the receiver's init parameters
  */
-int getzrxinit()
+int getzrxinit(void)
 {
 	register int n;
 	struct stat f;
@@ -1220,7 +1220,7 @@ int getzrxinit()
 }
 
 /* Send send-init information */
-int sendzsinit()
+int sendzsinit(void)
 {
 	register int c;
 
@@ -1308,7 +1308,7 @@ again:
 }
 
 /* Send the data in the file */
-int zsendfdata()
+int zsendfdata(void)
 {
 	register int c, e, n;
 	register int newcnt;
@@ -1564,7 +1564,7 @@ int getinsync(int flag)
 
 
 /* Say "bibi" to the receiver, try to do it cleanly */
-void saybibi()
+void saybibi(void)
 {
 	for (;;) {
 		stohdr(0L);		/* CAF Was zsbhdr - minor change */

--- a/minix/drivers/audio/sb16/mixer.c
+++ b/minix/drivers/audio/sb16/mixer.c
@@ -36,7 +36,7 @@ int mixer_ioctl(unsigned long request, void *val, int *UNUSED(len)) {
 /*=========================================================================*
  *				mixer_init				   
  *=========================================================================*/
-int mixer_init() {
+int mixer_init(void) {
 	/* Try to detect the mixer by writing to MIXER_DAC_LEVEL if the
 	* value written can be read back the mixer is there
 	*/

--- a/minix/drivers/system/random/main.c
+++ b/minix/drivers/system/random/main.c
@@ -67,7 +67,7 @@ int main(void)
 /*===========================================================================*
  *			       sef_local_startup			     *
  *===========================================================================*/
-static void sef_local_startup()
+static void sef_local_startup(void)
 {
   /* Register init callbacks. */
   sef_setcb_init_fresh(sef_cb_init_fresh);

--- a/minix/drivers/system/random/random.c
+++ b/minix/drivers/system/random/random.c
@@ -34,7 +34,7 @@ static void add_sample(int source, unsigned long sample);
 static void data_block(rd_keyinstance *keyp, void *data);
 static void reseed(void);
 
-void random_init()
+void random_init(void)
 {
 	int i, j;
 
@@ -54,17 +54,14 @@ void random_init()
 	reseed_count= 0;
 }
 
-int random_isseeded()
+int random_isseeded(void)
 {
 	if (got_seeded)
 		return 1;
 	return 0;
 }
 
-void random_update(source, buf, count)
-int source;
-rand_t *buf;
-int count;
+void random_update(int source, rand_t *buf, int count)
 {
 	int i;
 
@@ -78,9 +75,7 @@ int count;
 	reseed();
 }
 
-void random_getbytes(buf, size)
-void *buf;
-size_t size;
+void random_getbytes(void *buf, size_t size)
 {
 	int n, r;
 	u8_t *cp;
@@ -112,9 +107,7 @@ size_t size;
 	data_block(&key, random_key+AES_BLOCKSIZE);
 }
 
-void random_putbytes(buf, size)
-void *buf;
-size_t size;
+void random_putbytes(void *buf, size_t size)
 {
 	/* Add bits to pool zero */
 	SHA256_Update(&pool_ctx[0], buf, size);
@@ -127,9 +120,7 @@ size_t size;
 	reseed();
 }
 
-static void add_sample(source, sample)
-int source;
-unsigned long sample;
+static void add_sample(int source, unsigned long sample)
 {
 	int i, pool_nr;
 	unsigned long d, v, di, min;
@@ -178,9 +169,7 @@ unsigned long sample;
 	pool_ind[source]= pool_nr;
 }
 
-static void data_block(keyp, data)
-rd_keyinstance *keyp;
-void *data;
+static void data_block(rd_keyinstance *keyp, void *data)
 {
 	int r;
 	u8_t input[AES_BLOCKSIZE];
@@ -203,7 +192,7 @@ void *data;
 		count_hi++;
 }
 
-static void reseed()
+static void reseed(void)
 {
 	int i;
 	SHA256_CTX ctx;

--- a/minix/drivers/tty/tty/arch/i386/console.c
+++ b/minix/drivers/tty/tty/arch/i386/console.c
@@ -155,10 +155,9 @@ static struct chardriver video_tab = {
 
 /*===========================================================================*
  *				cons_write				     *
+ *				tp tells which terminal is to be used *
  *===========================================================================*/
-static int cons_write(tp, try)
-register struct tty *tp;	/* tells which terminal is to be used */
-int try;
+static int cons_write(register struct tty *tp, int try)
 {
 /* Copy as much data as possible to the output queue, then start I/O.  On
  * memory-mapped terminals, such as the IBM console, the I/O will also be
@@ -236,10 +235,10 @@ int try;
 
 /*===========================================================================*
  *				cons_echo				     *
+ *				tp pointer to tty struct
+ *				c character to be echoed
  *===========================================================================*/
-static void cons_echo(tp, c)
-register tty_t *tp;		/* pointer to tty struct */
-int c;				/* character to be echoed */
+static void cons_echo(register tty_t *tp, int c)
 {
 /* Echo keyboard input (print & flush). */
   console_t *cons = tp->tty_priv;
@@ -250,10 +249,10 @@ int c;				/* character to be echoed */
 
 /*===========================================================================*
  *				out_char				     *
+ *				cons - pointer to console struct
+ *				c - character to output
  *===========================================================================*/
-static void out_char(cons, c)
-register console_t *cons;	/* pointer to console struct */
-int c;				/* character to be output */
+static void out_char(register console_t *cons, int c)
 {
 /* Output a character on the console.  Check for escape sequences first. */
   if (cons->c_esc_state > 0) {
@@ -345,10 +344,10 @@ int c;				/* character to be output */
 
 /*===========================================================================*
  *				scroll_screen				     *
+ *				cons - pointer to console struct
+ *				dir - SCROLL_UP or SCROLL_DOWN
  *===========================================================================*/
-static void scroll_screen(cons, dir)
-register console_t *cons;	/* pointer to console struct */
-int dir;			/* SCROLL_UP or SCROLL_DOWN */
+static void scroll_screen(register console_t *cons, int dir)
 {
   unsigned new_line, new_org, chars;
 
@@ -397,9 +396,9 @@ int dir;			/* SCROLL_UP or SCROLL_DOWN */
 
 /*===========================================================================*
  *				flush					     *
+ *				cons - pointer to console struct
  *===========================================================================*/
-static void flush(cons)
-register console_t *cons;	/* pointer to console struct */
+static void flush(register console_t *cons)
 {
 /* Send characters buffered in 'ramqueue' to screen memory, check the new
  * cursor position, compute the new hardware cursor position and set it.
@@ -429,10 +428,10 @@ register console_t *cons;	/* pointer to console struct */
 
 /*===========================================================================*
  *				parse_escape				     *
+ *				cons pointer to console struct
+ *				c next character in escape sequence
  *===========================================================================*/
-static void parse_escape(cons, c)
-register console_t *cons;	/* pointer to console struct */
-char c;				/* next character in escape sequence */
+static void parse_escape(register console_t *cons, int c)
 {
 /* The following ANSI escape sequences are currently supported.
  * If n and/or m are omitted, they default to 1.
@@ -487,11 +486,11 @@ char c;				/* next character in escape sequence */
 }
 
 /*===========================================================================*
- *				do_escape				     *
+ *				do_escape													 *
+ *				cons: pointer to console struct								 *
+ *				c: next character in escape sequence						 *
  *===========================================================================*/
-static void do_escape(cons, c)
-register console_t *cons;	/* pointer to console struct */
-char c;				/* next character in escape sequence */
+static void do_escape(register console_t *cons, int c)
 {
   int value, n;
   unsigned src, dst, count;
@@ -729,11 +728,11 @@ char c;				/* next character in escape sequence */
 }
 
 /*===========================================================================*
- *				set_6845				     *
+ *				set_6845													 *
+ *				reg: which register pair to set								 *
+ *				val: 16-bit value to set it to								 *
  *===========================================================================*/
-static void set_6845(reg, val)
-int reg;			/* which register pair to set */
-unsigned val;			/* 16-bit value to set it to */
+static void set_6845(int reg, unsigned val)
 {
 /* Set a register pair inside the 6845.
  * Registers 12-13 tell the 6845 where in video ram to start
@@ -751,9 +750,9 @@ unsigned val;			/* 16-bit value to set it to */
 /*===========================================================================*
  *				get_6845				     *
  *===========================================================================*/
-static void get_6845(reg, val)
-int reg;			/* which register pair to set */
-unsigned *val;			/* 16-bit value to set it to */
+static void get_6845(int reg, unsigned *val)
+/* int reg;			/* which register pair to set */
+/* unsigned *val;			/* 16-bit value to set it to */
 {
   char v1, v2;
   u32_t v;
@@ -789,7 +788,7 @@ static long beep_disabled(void)
 /*===========================================================================*
  *				beep					     *
  *===========================================================================*/
-static void beep()
+static void beep(void)
 {
 /* Making a beeping sound on the speaker (output for CRTL-G).
  * This routine works by turning on the bits 0 and 1 in port B of the 8255
@@ -858,9 +857,7 @@ void do_video(message *m, int ipc_status)
 /*===========================================================================*
  *				beep_x					     *
  *===========================================================================*/
-void beep_x(freq, dur)
-unsigned freq;
-clock_t dur;
+void beep_x(unsigned freq, clock_t dur)
 {
 /* Making a beeping sound on the speaker.
  * This routine works by turning on the bits 0 and 1 in port B of the 8255
@@ -907,8 +904,7 @@ static void stop_beep(int arg __unused)
 /*===========================================================================*
  *				scr_init				     *
  *===========================================================================*/
-void scr_init(tp)
-tty_t *tp;
+void scr_init(tty_t *tp)
 {
 /* Initialize the screen driver. */
   console_t *cons;
@@ -1009,7 +1005,7 @@ tty_t *tp;
 /*===========================================================================*
  *				toggle_scroll				     *
  *===========================================================================*/
-void toggle_scroll()
+void toggle_scroll(void)
 {
 /* Toggle between hardware and software scroll. */
 
@@ -1021,7 +1017,7 @@ void toggle_scroll()
 /*===========================================================================*
  *				cons_stop				     *
  *===========================================================================*/
-void cons_stop()
+void cons_stop(void)
 {
 /* Prepare for halt or reboot. */
   cons_org0();
@@ -1034,7 +1030,7 @@ void cons_stop()
 /*===========================================================================*
  *				cons_org0				     *
  *===========================================================================*/
-static void cons_org0()
+static void cons_org0(void)
 {
 /* Scroll video memory back to put the origin at 0. */
   int cons_line;
@@ -1058,7 +1054,7 @@ static void cons_org0()
 /*===========================================================================*
  *				disable_console				     *
  *===========================================================================*/
-static void disable_console()
+static void disable_console(void)
 {
 	if (disabled_vc != -1)
 		return;
@@ -1076,7 +1072,7 @@ static void disable_console()
 /*===========================================================================*
  *				reenable_console			     *
  *===========================================================================*/
-static void reenable_console()
+static void reenable_console(void)
 {
 	if (disabled_vc == -1)
 		return;
@@ -1146,8 +1142,7 @@ int con_loadfont(endpoint_t endpt, cp_grant_id_t grant)
 /*===========================================================================*
  *				ga_program				     *
  *===========================================================================*/
-static int ga_program(seq)
-struct sequence *seq;
+static int ga_program(struct sequence *seq)
 {
   pvb_pair_t char_out[14];
   int i;

--- a/minix/drivers/tty/tty/arch/i386/keyboard.c
+++ b/minix/drivers/tty/tty/arch/i386/keyboard.c
@@ -86,8 +86,7 @@ static unsigned map_key(int scode);
 /*===========================================================================*
  *				map_key					     *
  *===========================================================================*/
-static unsigned map_key(scode)
-int scode;
+static unsigned map_key(int scode)
 {
 /* Map a scan code to an ASCII code. */
 
@@ -181,9 +180,7 @@ void do_input(message *msg)
 /*===========================================================================*
  *				kb_read					     *
  *===========================================================================*/
-static int kb_read(tp, try)
-tty_t *tp;
-int try;
+static int kb_read(tty_t *tp, int try)
 {
 /* Process characters from the circular keyboard buffer. */
   char buf[7], *p, suffix;
@@ -387,8 +384,7 @@ static void set_leds(void)
 /*===========================================================================*
  *				kb_init					     *
  *===========================================================================*/
-void kb_init(tp)
-tty_t *tp;
+void kb_init(tty_t *tp)
 {
 /* Initialize the keyboard driver. */
 
@@ -425,9 +421,9 @@ int kbd_loadmap(endpoint_t endpt, cp_grant_id_t grant)
 
 /*===========================================================================*
  *				do_fkey_ctl				     *
+ *				m_ptr pointer to request message
  *===========================================================================*/
-void do_fkey_ctl(m_ptr)
-message *m_ptr;			/* pointer to the request message */
+void do_fkey_ctl(message *m_ptr)
 {
 /* This procedure allows processes to register a function key to receive
  * notifications if it is pressed. At most one binding per key can exist.
@@ -527,10 +523,10 @@ message *m_ptr;			/* pointer to the request message */
 }
 
 /*===========================================================================*
- *				func_key				     *
+ *				func_key													 *
+ *				scode: scan code for a function key							 *
  *===========================================================================*/
-static int func_key(scode)
-int scode;			/* scan code for a function key */
+static int func_key(int scode)
 {
 /* This procedure traps function keys for debugging purposes. Observers of 
  * function keys are kept in a global array. If a subject (a key) is pressed
@@ -574,7 +570,7 @@ int scode;			/* scan code for a function key */
 /*===========================================================================*
  *				show_key_mappings			     *
  *===========================================================================*/
-static void show_key_mappings()
+static void show_key_mappings(void)
 {
     int i,s;
 

--- a/minix/drivers/tty/tty/arch/i386/rs232.c
+++ b/minix/drivers/tty/tty/arch/i386/rs232.c
@@ -312,11 +312,11 @@ static int rs_write(register tty_t *tp, int try)
 }
 
 /*===========================================================================*
- *				rs_echo					     *
+ *				rs_echo														 *
+ *				tp: which TTY												 *
+ *				c: character to echo										 *
  *===========================================================================*/
-static void rs_echo(tp, c)
-tty_t *tp;			/* which TTY */
-int c;				/* character to echo */
+static void rs_echo(tty_t *tp, int c)
 {
 /* Echo one character.  (Like rs_write, but only one character, optionally.) */
 

--- a/minix/drivers/video/fb/fb.c
+++ b/minix/drivers/video/fb/fb.c
@@ -316,7 +316,7 @@ main(int argc, char *argv[])
 }
 
 static int
-keep_displaying_restarted()
+keep_displaying_restarted(void)
 {
 	u64_t delta;
 	u32_t micro_delta;


### PR DESCRIPTION
This was stated in Minix3 wishlist.