### PR TITLE
Fix GCC 10+ cross-compiling issues

### DIFF
--- a/bin/pax/extern.h
+++ b/bin/pax/extern.h
@@ -204,7 +204,6 @@ void options(int, char **);
 OPLIST * opt_next(void);
 int bad_opt(void);
 int mkpath(char *);
-char *chdname;
 #if !HAVE_NBTOOL_CONFIG_H
 int do_chroot;
 #endif

--- a/bin/pax/options.c
+++ b/bin/pax/options.c
@@ -214,6 +214,8 @@ int havechd = 0;
  *	parser
  */
 
+char *chdname;
+
 void
 options(int argc, char **argv)
 {

--- a/external/bsd/llvm/dist/llvm/include/llvm/IR/ValueMap.h
+++ b/external/bsd/llvm/dist/llvm/include/llvm/IR/ValueMap.h
@@ -101,7 +101,7 @@ public:
 
   ~ValueMap() {}
 
-  bool hasMD() const { return MDMap; }
+  bool hasMD() const { return (bool)MDMap; }
   MDMapT &MD() {
     if (!MDMap)
       MDMap.reset(new MDMapT);

--- a/sbin/newfs_udf/newfs_udf.h
+++ b/sbin/newfs_udf/newfs_udf.h
@@ -53,8 +53,8 @@ extern float	 meta_fract;
 
 
 /* shared structure between udf_create.c users */
-struct udf_create_context context;
-struct udf_disclayout     layout;
+extern struct udf_create_context context;
+extern struct udf_disclayout     layout;
 
 /* prototypes */
 int udf_write_sector(void *sector, uint64_t location);

--- a/sbin/newfs_udf/udf_create.c
+++ b/sbin/newfs_udf/udf_create.c
@@ -52,6 +52,10 @@ __RCSID("$NetBSD: udf_create.c,v 1.25 2015/06/16 23:18:55 christos Exp $");
 #  endif
 #endif
 
+/* shared structure between udf_create.c users */
+struct udf_create_context context;
+struct udf_disclayout     layout;
+
 /*
  * NOTE that there is some overlap between this code and the udf kernel fs.
  * This is intentially though it might better be factored out one day.

--- a/usr.bin/make/main.c
+++ b/usr.bin/make/main.c
@@ -192,6 +192,8 @@ char *makeDependfile;
 pid_t myPid;
 int makelevel;
 
+FILE *debug_file;
+
 Boolean forceJobs = FALSE;
 
 extern Lst parseIncPath;

--- a/usr.bin/make/make.h
+++ b/usr.bin/make/make.h
@@ -440,7 +440,7 @@ extern pid_t	myPid;
  *	There is one bit per module.  It is up to the module what debug
  *	information to print.
  */
-FILE *debug_file;		/* Output written here - default stdout */
+extern FILE *debug_file;		/* Output written here - default stdout */
 extern int debug;
 #define	DEBUG_ARCH	0x00001
 #define	DEBUG_COND	0x00002

--- a/usr.sbin/installboot/machines.c
+++ b/usr.sbin/installboot/machines.c
@@ -48,13 +48,11 @@ __RCSID("$NetBSD: machines.c,v 1.39 2014/02/24 07:23:44 skrll Exp $");
  */
 struct ib_mach
     ib_mach_alpha,
-    ib_mach_amd64,
     ib_mach_amiga,
     ib_mach_emips,
     ib_mach_ews4800mips,
     ib_mach_hp300,
     ib_mach_hppa,
-    ib_mach_i386,
     ib_mach_landisk,
     ib_mach_macppc,
     ib_mach_news68k,


### PR DESCRIPTION
**Not to be merged.**

I hope this patchset will help newcomers to cross-compile MINIX.

Current master cannot be cross-compiled due to gcc breaking changes.
This patchset is a workaround for this problem until source tree is synchronized
with current NetBSD.
There is a binutils patch which I cannot add to pull request, so I link
it here: https://gist.github.com/petershh/1973b8f723fb36242c9558a23408d469

Closes: #316