### PR TITLE
at_wini: use sys_vumap instead of sys_umap for DMA

### DIFF
--- a/etc/system.conf
+++ b/etc/system.conf
@@ -334,7 +334,7 @@ service at_wini
 		15		# Controller 1
 	;
 	system
-		UMAP		# 14
+		VUMAP		# 18
 		IRQCTL		# 19
 		DEVIO		# 21
 		SDEVIO		# 22


### PR DESCRIPTION
This 1) makes driver faster, since only one kernel call is issued; 2) Fixes ext2 on IDE drives