### PR TITLE
[cross-compile] Improve fetching external projects and building speed, and fix compiling  with more recent version of GCC

### DIFF
--- a/bin/pax/extern.h
+++ b/bin/pax/extern.h
@@ -204,7 +204,6 @@ void options(int, char **);
 OPLIST * opt_next(void);
 int bad_opt(void);
 int mkpath(char *);
-char *chdname;
 #if !HAVE_NBTOOL_CONFIG_H
 int do_chroot;
 #endif

--- a/bin/pax/options.c
+++ b/bin/pax/options.c
@@ -214,6 +214,8 @@ int havechd = 0;
  *	parser
  */
 
+char *chdname;
+
 void
 options(int argc, char **argv)
 {

--- a/external/bsd/llvm/dist/llvm/include/llvm/IR/ValueMap.h
+++ b/external/bsd/llvm/dist/llvm/include/llvm/IR/ValueMap.h
@@ -101,7 +101,7 @@ public:
 
   ~ValueMap() {}
 
-  bool hasMD() const { return MDMap; }
+  bool hasMD() const { return (bool)MDMap; }
   MDMapT &MD() {
     if (!MDMap)
       MDMap.reset(new MDMapT);

--- a/external/gpl3/binutils/fetch.sh
+++ b/external/gpl3/binutils/fetch.sh
@@ -5,8 +5,8 @@ echo $0
 cd `dirname $0`
 
 # Configure fetch method
-URL="http://www.minix3.org/pkgsrc/distfiles/minix/3.4.0/binutils-2.23.2.tar.bz2"
-BACKUP_URL="http://ftp.gnu.org/gnu/binutils/binutils-2.23.2.tar.bz2"
+URL="https://ftpmirror.gnu.org/gnu/binutils/binutils-2.23.2.tar.bz2"
+BACKUP_URL="http://www.minix3.org/pkgsrc/distfiles/minix/3.4.0/binutils-2.23.2.tar.bz2"
 FETCH=ftp
 which curl >/dev/null
 if [ $? -eq 0 ]; then

--- a/external/gpl3/binutils/patches/0011-fix-gold-errors-header.patch
+++ b/external/gpl3/binutils/patches/0011-fix-gold-errors-header.patch
@@ -1,0 +1,10 @@
+--- dist.orig/gold/errors.h	2011-06-08 04:43:28.000000000 +0000
++++ dist/gold/errors.h	2024-03-04 06:53:40.580217099 +0000
+@@ -24,6 +24,7 @@
+ #define GOLD_ERRORS_H
+ 
+ #include <cstdarg>
++#include <string>
+ 
+ #include "gold-threads.h"
+ 

--- a/external/gpl3/gcc/fetch.sh
+++ b/external/gpl3/gcc/fetch.sh
@@ -9,8 +9,9 @@ cd `dirname $0`
 : ${SED=sed}
 
 # Configure fetch method
-URL="http://www.minix3.org/pkgsrc/distfiles/minix/3.4.0/gcc-4.8.5.tar.bz2"
-BACKUP_URL="ftp://ftp.gwdg.de/pub/misc/gcc/releases/gcc-4.8.5/gcc-4.8.5.tar.bz2"
+# URL="http://www.minix3.org/pkgsrc/distfiles/minix/3.4.0/gcc-4.8.5.tar.bz2"
+URL="https://ftpmirror.gnu.org/gnu/gcc/gcc-4.8.5/gcc-4.8.5.tar.bz2"
+BACKUP_URL="http://www.minix3.org/pkgsrc/distfiles/minix/3.4.0/gcc-4.8.5.tar.bz2"
 FETCH=ftp
 if which curl >/dev/null
 then

--- a/external/gpl3/gcc/patches/0005-fix-gcc-reloads.patch
+++ b/external/gpl3/gcc/patches/0005-fix-gcc-reloads.patch
@@ -1,0 +1,16 @@
+--- dist.orig/gcc/reload1.c	2013-01-21 14:55:05.000000000 +0000
++++ dist/gcc/reload1.c	2024-03-04 09:27:54.119538490 +0000
+@@ -436,11 +436,11 @@
+ 				 gen_rtx_REG (Pmode,
+ 					      LAST_VIRTUAL_REGISTER + 1),
+ 				 GEN_INT (4)));
+-  spill_indirect_levels = 0;
++  spill_indirect_levels = false;
+ 
+   while (memory_address_p (QImode, tem))
+     {
+-      spill_indirect_levels++;
++      spill_indirect_levels = true;
+       tem = gen_rtx_MEM (Pmode, tem);
+     }
+ 

--- a/releasetools/arm_sdimage.sh
+++ b/releasetools/arm_sdimage.sh
@@ -23,6 +23,8 @@ fi
 : ${OBJ=../obj.${ARCH}}
 : ${TOOLCHAIN_TRIPLET=arm-elf32-minix-}
 : ${BUILDSH=build.sh}
+# Set the number of parallel build jobs the same number of CPU cores.
+: ${JOBS=$(nproc)}
 
 : ${SETS="minix-base minix-comp minix-games minix-man minix-tests tests"}
 : ${IMG=minix_arm_sd.img}

--- a/sbin/newfs_udf/newfs_udf.h
+++ b/sbin/newfs_udf/newfs_udf.h
@@ -53,8 +53,8 @@ extern float	 meta_fract;
 
 
 /* shared structure between udf_create.c users */
-struct udf_create_context context;
-struct udf_disclayout     layout;
+extern struct udf_create_context context;
+extern struct udf_disclayout     layout;
 
 /* prototypes */
 int udf_write_sector(void *sector, uint64_t location);

--- a/sbin/newfs_udf/udf_create.c
+++ b/sbin/newfs_udf/udf_create.c
@@ -52,6 +52,10 @@ __RCSID("$NetBSD: udf_create.c,v 1.25 2015/06/16 23:18:55 christos Exp $");
 #  endif
 #endif
 
+/* shared structure between udf_create.c users */
+struct udf_create_context context;
+struct udf_disclayout     layout;
+
 /*
  * NOTE that there is some overlap between this code and the udf kernel fs.
  * This is intentially though it might better be factored out one day.

--- a/usr.bin/make/main.c
+++ b/usr.bin/make/main.c
@@ -192,6 +192,8 @@ char *makeDependfile;
 pid_t myPid;
 int makelevel;
 
+FILE *debug_file;
+
 Boolean forceJobs = FALSE;
 
 extern Lst parseIncPath;

--- a/usr.bin/make/make.h
+++ b/usr.bin/make/make.h
@@ -440,7 +440,7 @@ extern pid_t	myPid;
  *	There is one bit per module.  It is up to the module what debug
  *	information to print.
  */
-FILE *debug_file;		/* Output written here - default stdout */
+extern FILE *debug_file;		/* Output written here - default stdout */
 extern int debug;
 #define	DEBUG_ARCH	0x00001
 #define	DEBUG_COND	0x00002

--- a/usr.sbin/installboot/machines.c
+++ b/usr.sbin/installboot/machines.c
@@ -48,13 +48,11 @@ __RCSID("$NetBSD: machines.c,v 1.39 2014/02/24 07:23:44 skrll Exp $");
  */
 struct ib_mach
     ib_mach_alpha,
-    ib_mach_amd64,
     ib_mach_amiga,
     ib_mach_emips,
     ib_mach_ews4800mips,
     ib_mach_hp300,
     ib_mach_hppa,
-    ib_mach_i386,
     ib_mach_landisk,
     ib_mach_macppc,
     ib_mach_news68k,


### PR DESCRIPTION
## Acknowledgements

Thanks [petershh](https://github.com/petershh) for submitting a related PR #322 which fixes multiple strong symbol conflict during linking, I have also included the commit in this PR

## Description

So far, I have made three changes:

1. Fetch external projects (to be specific, `gcc` and `binutils`) from `ftpmirror.gnu.org` rather than `www.minix3.org` for speed-up (10 MB/s vs ~50 KB/s).

2. Use as much CPU cores as possible. At least for cross-compiling, the default number (it is 1) of core to use is specified in [releasetools/image.defaults](https://github.com/Stichting-MINIX-Research-Foundation/minix/blob/4db99f4012570a577414fe2a43697b2f239b699e/releasetools/image.defaults#L4).

3. Fix building with more recent version of GCC (I am compiling Minix on an Ubuntu 22.04 container with GCC 11.4). These fixes are added in the form of `*.patch` files. Here is my way of generating them:

```bash
cd external/gpl3/gcc
mkdir dist.orig
tar -C dist.orig --strip-components=1 gcc-4.8.5.tar.bz2
diff --color -u dist.orig/gcc/reload1.c dist/gcc/reload1.c > patches/0005-fix-gcc-reloads.patch
git add -f patches/0005-fix-gcc-reloads.patch
```

By the way, patches will be applied by [fetch.sh](https://github.com/Stichting-MINIX-Research-Foundation/minix/blob/4db99f4012570a577414fe2a43697b2f239b699e/external/gpl3/gcc/fetch.sh#L65).