### PR TITLE
Add UEFI boot support via GRUB 2.06 EFI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ external/bsd/llvm/dist/clang/test/CodeGenCXX/microsoft-abi-vtables-multiple-nonv
 external/bsd/llvm/dist/llvm/test/Verifier/bitcast-address-space-through-constant-inttoptr-inside-gep-i
 lib/libc/compat__*
 .gdbinit
+# Build artifacts
+minix_x86.img
+releasetools/grub/
+obj/
+*.img

--- a/minix/drivers/tty/tty/arch/i386/console.c
+++ b/minix/drivers/tty/tty/arch/i386/console.c
@@ -950,6 +950,13 @@ tty_t *tp;
   	font_lines = bios_fontlines;
 	scr_lines = bios_rows+1;
 
+	/* UEFI boot: BDA has no VGA parameters (all zeros).
+	 * Disable the console driver to prevent divide-by-zero. */
+	if (bios_crtbase == 0 && bios_columns == 0) {
+		nr_cons = 0;
+		return;
+	}
+
   	if (color) {
 		vid_base = COLOR_BASE;
 		vid_size = COLOR_SIZE;

--- a/minix/kernel/arch/i386/direct_tty_utils.c
+++ b/minix/kernel/arch/i386/direct_tty_utils.c
@@ -7,6 +7,12 @@
 #include "serial.h"
 #include "glo.h"
 
+/* When set to 0 (e.g., novga=1 boot param), all VGA memory writes
+ * and 6845 I/O port access are suppressed.  Output goes only through
+ * ser_putc() in kputc.  Required for UEFI boot where there is no
+ * BIOS VGA text mode. */
+int direct_con_mode = 1;
+
 /* Give non-zero values to avoid them in BSS */
 static int print_line = 1, print_col = 1;
 
@@ -16,9 +22,11 @@ extern char *video_mem;
 #define VIDOFFSET(line, col) ((line) * MULTIBOOT_CONSOLE_COLS * 2 + (col) * 2)
 #define VIDSIZE VIDOFFSET(MULTIBOOT_CONSOLE_LINES-1,MULTIBOOT_CONSOLE_COLS-1)
 
-void direct_put_char(char c, int line, int col) 
+void direct_put_char(char c, int line, int col)
 {
-	int offset = VIDOFFSET(line, col);
+	int offset;
+	if (!direct_con_mode) return;
+	offset = VIDOFFSET(line, col);
 	video_mem[offset] = c;
 	video_mem[offset+1] = 0x07;	/* grey-on-black */
 }
@@ -32,6 +40,11 @@ void direct_cls(void)
 {
 	/* Clear screen */
 	int i,j;
+
+	if (!direct_con_mode) {
+		print_line = print_col = 0;
+		return;
+	}
 
 	for(i = 0; i < MULTIBOOT_CONSOLE_COLS; i++)
 		for(j = 0; j < MULTIBOOT_CONSOLE_LINES; j++)

--- a/minix/kernel/arch/i386/head.S
+++ b/minix/kernel/arch/i386/head.S
@@ -29,17 +29,11 @@ IMPORT(mon_ds)
 IMPORT(switch_to_user)
 IMPORT(multiboot_init)
 
-.text
-/*===========================================================================*/
-/*				MINIX				     */
-/*===========================================================================*/
-.global MINIX
-MINIX:
-/* this is the entry point for the MINIX kernel */
-	jmp multiboot_init
-
-/* Multiboot header here*/
-
+/* Multiboot header in its own section so the linker script can
+ * place it within the first 8KB of the binary, as required by
+ * the multiboot specification.  Without this, GRUB EFI cannot
+ * find the header. */
+.section .multiboot, "ax"
 .balign 8
 
 #define MULTIBOOT_FLAGS (MULTIBOOT_HEADER_WANT_MEMORY | MULTIBOOT_HEADER_MODS_ALIGNED)
@@ -64,6 +58,12 @@ multiboot_height:
 	.long MULTIBOOT_CONSOLE_LINES
 multiboot_depth:
 	.long 0
+
+/* Entry point and remaining code in .text */
+.text
+.global MINIX
+MINIX:
+	jmp multiboot_init
 
 multiboot_init:
 	mov	$load_stack_start, %esp	/* make usable stack */

--- a/minix/kernel/arch/i386/kernel.lds
+++ b/minix/kernel/arch/i386/kernel.lds
@@ -12,6 +12,15 @@ __k_unpaged__kern_phys_base = _kern_phys_base;
 SECTIONS
 {
 	. = _kern_phys_base;
+
+	/* Multiboot header must be in the first 8KB for GRUB EFI */
+	.multiboot : { *(.multiboot) }
+
+	/* Discard .eh_frame to prevent it from being placed before
+	 * the multiboot header (it's ~15KB and would push the header
+	 * beyond the 8KB multiboot spec limit). */
+	/DISCARD/ : { *(.eh_frame) *(.eh_frame_hdr) }
+
 	__k_unpaged__kern_unpaged_start = .;
 
 	.unpaged_text : { unpaged_*.o(.text) }

--- a/minix/kernel/arch/i386/pre_init.c
+++ b/minix/kernel/arch/i386/pre_init.c
@@ -142,6 +142,14 @@ void get_parameters(u32_t ebx, kinfo_t *cbi)
 			value[value_i] = 0;
 			
 			mb_set_param(cbi->param_buf, var, value, cbi);
+
+			/* novga=1: disable VGA console (UEFI boot) */
+			if (var_i == 5 && var[0]=='n' && var[1]=='o' &&
+			    var[2]=='v' && var[3]=='g' && var[4]=='a' &&
+			    value[0] == '1') {
+				extern int direct_con_mode;
+				direct_con_mode = 0;
+			}
 		}
 	}
 

--- a/releasetools/image.functions
+++ b/releasetools/image.functions
@@ -260,77 +260,97 @@ create_protos()
 #
 fetch_and_build_grub()
 {
-       if [ -d ${RELEASETOOLSDIR}/grub ]
+       if [ -f ${RELEASETOOLSDIR}/grub/grub-core/booti386.efi ] && \
+          [ -f ${RELEASETOOLSDIR}/grub/grub-core/bootx64.efi ]
        then
-         echo grub is already checked out
-       else
-         git clone git://git.savannah.gnu.org/grub.git ${RELEASETOOLSDIR}/grub
-         pushd ${RELEASETOOLSDIR}/grub
-         # most recent known working commit at the time of writing
-         git checkout a0bf403f66dbaca4edd8e667bfc397dd91c8d71c
-         ./autogen.sh
-         ./configure --with-platform=efi --target=i386
-         make clean
-         make -j ${JOBS}
-         cd grub-core
-         ../grub-mkimage -v -d . -o booti386.efi -O i386-efi -p /boot/efi normal part_msdos fat chain boot configfile multiboot minix3 gzio efi_uga
-         ls -l booti386.efi
-         popd
+         echo "GRUB EFI binaries already built"
+         return
        fi
+
+       rm -rf ${RELEASETOOLSDIR}/grub
+       local _grub_ver="2.06"
+       local _grub_tar="grub-${_grub_ver}.tar.xz"
+       local _grub_url="https://ftp.gnu.org/gnu/grub/${_grub_tar}"
+
+       echo "Downloading GRUB ${_grub_ver}..."
+       if ! curl -fSL -o "/tmp/${_grub_tar}" "${_grub_url}"; then
+         bomb "Failed to download GRUB from ${_grub_url}"
+       fi
+       tar xf "/tmp/${_grub_tar}" -C ${RELEASETOOLSDIR}
+       mv ${RELEASETOOLSDIR}/grub-${_grub_ver} ${RELEASETOOLSDIR}/grub
+
+       GRUB_MODULES="normal part_msdos fat chain boot configfile"
+       GRUB_MODULES="$GRUB_MODULES multiboot serial gzio efi_gop all_video"
+
+       pushd ${RELEASETOOLSDIR}/grub
+
+       # Build i386-efi (for 32-bit UEFI firmware)
+       echo "Building GRUB i386-efi..."
+       ./configure --with-platform=efi --target=i386 --disable-werror \
+           --disable-nls
+       make -j ${JOBS}
+       cd grub-core
+       ../grub-mkimage -d . -o booti386.efi -O i386-efi \
+           -p /boot/grub ${GRUB_MODULES}
+       ls -l booti386.efi
+
+       # Build x86_64-efi (for 64-bit UEFI firmware)
+       echo "Building GRUB x86_64-efi..."
+       cd ..
+       make clean
+       ./configure --with-platform=efi --target=x86_64 --disable-werror \
+           --disable-nls
+       make -j ${JOBS}
+       cd grub-core
+       ../grub-mkimage -d . -o bootx64.efi -O x86_64-efi \
+           -p /boot/grub ${GRUB_MODULES}
+       ls -l bootx64.efi
+
+       popd
+       rm -f "/tmp/${_grub_tar}"
 }
 
 #
-# Create grub.cfg for efi boot
+# Create grub.cfg for EFI boot
 #
 create_grub_cfg()
 {
-	cat > ${EFI_DIR}/boot/efi/grub.cfg <<END_GRUBCFG
+	local _grub_dir="${EFI_DIR}/boot/grub"
 
+	# Generate module lines dynamically from actual module files
+	local _mods=""
+	for _m in ${EFI_DIR}/boot/minix_default/mod*; do
+		_mods="${_mods}	module /boot/minix_default/$(basename ${_m})
+"
+	done
+
+	# GRUB reads files from the EFI partition (FAT16) since it cannot
+	# read MINIX MFS partitions.  Kernel and modules are stored on the
+	# EFI partition under /boot/minix_default/.
+	# The EFI partition is partition 4 in MBR (hd0,msdos4).
+	cat > ${_grub_dir}/grub.cfg <<END_GRUBCFG
 insmod serial
-insmod minix3
 insmod gzio
-#insmod efi_uga
-#insmod video_fb
 insmod all_video
+insmod fat
+insmod part_msdos
 
-set timeout=30
+serial --unit=0 --speed=115200
+terminal_input serial console
+terminal_output serial console
+
+set timeout=10
 set default=0
 
-set gfxmode=text
+menuentry "MINIX 3 (serial + video)" {
+	set root=(hd0,msdos4)
+	multiboot /boot/minix_default/kernel rootdevname=c0d0p0 novga=1
+${_mods}}
 
-menuentry "Minix Boot" {
-        set root=(hd0,1)
-        multiboot /boot/minix_default/kernel rootdevname=c0d0p0
-        module /boot/minix_default/mod01_ds
-        module /boot/minix_default/mod02_rs
-        module /boot/minix_default/mod03_pm
-        module /boot/minix_default/mod04_sched
-        module /boot/minix_default/mod05_vfs
-        module /boot/minix_default/mod06_memory
-        module /boot/minix_default/mod07_tty
-        module /boot/minix_default/mod08_mib
-        module /boot/minix_default/mod09_vm
-        module /boot/minix_default/mod10_pfs
-        module /boot/minix_default/mod11_mfs
-        module /boot/minix_default/mod12_init
-}
-
-menuentry "Minix Boot (serial)" {
-        set root=(hd0,1)
-        multiboot /boot/minix_default/kernel rootdevname=c0d0p0 cttyline=0 ttybaud=115200 console=tty00 consdev=com0
-        module /boot/minix_default/mod01_ds
-        module /boot/minix_default/mod02_rs
-        module /boot/minix_default/mod03_pm
-        module /boot/minix_default/mod04_sched
-        module /boot/minix_default/mod05_vfs
-        module /boot/minix_default/mod06_memory
-        module /boot/minix_default/mod07_tty
-        module /boot/minix_default/mod08_mib
-        module /boot/minix_default/mod09_vm
-        module /boot/minix_default/mod10_pfs
-        module /boot/minix_default/mod11_mfs
-        module /boot/minix_default/mod12_init
-}
+menuentry "MINIX 3 (serial only)" {
+	set root=(hd0,msdos4)
+	multiboot /boot/minix_default/kernel rootdevname=c0d0p0 novga=1 cttyline=0 ttybaud=115200 console=tty00
+${_mods}}
 END_GRUBCFG
 }
 

--- a/releasetools/x86_hdimage.sh
+++ b/releasetools/x86_hdimage.sh
@@ -26,7 +26,7 @@ fi
 : ${ROOT_SIZE=$((  128*(2**20) - ${BOOTXX_SECS} * 512 ))}
 : ${HOME_SIZE=$((  128*(2**20) ))}
 : ${USR_SIZE=$((  1792*(2**20) ))}
-: ${EFI_SIZE=$((  0  ))}
+: ${EFI_SIZE=$(( 10*(2**20) ))}
 
 # set up disk creation environment
 . releasetools/image.defaults
@@ -86,11 +86,23 @@ then
        fetch_and_build_grub
 
        : ${EFI_DIR=$OBJ/efi}
-       rm -rf ${EFI_DIR} && mkdir -p ${EFI_DIR}/boot/minix_default ${EFI_DIR}/boot/efi
-       create_grub_cfg
+       rm -rf ${EFI_DIR}
+       mkdir -p ${EFI_DIR}/EFI/BOOT
+       mkdir -p ${EFI_DIR}/boot/minix_default
+       mkdir -p ${EFI_DIR}/boot/grub
+
+       # Copy boot modules
        cp ${MODDIR}/* ${EFI_DIR}/boot/minix_default/
-       cp ${RELEASETOOLSDIR}/grub/grub-core/booti386.efi ${EFI_DIR}/boot/efi
-       cp ${RELEASETOOLSDIR}/grub/grub-core/*.mod ${EFI_DIR}/boot/efi
+
+       # Install GRUB EFI binaries in standard UEFI paths
+       cp ${RELEASETOOLSDIR}/grub/grub-core/booti386.efi \
+          ${EFI_DIR}/EFI/BOOT/BOOTIA32.EFI
+       cp ${RELEASETOOLSDIR}/grub/grub-core/bootx64.efi \
+          ${EFI_DIR}/EFI/BOOT/BOOTX64.EFI
+       # GRUB modules for runtime loading
+       cp ${RELEASETOOLSDIR}/grub/grub-core/*.mod ${EFI_DIR}/boot/grub/ 2>/dev/null
+
+       create_grub_cfg
 fi
 
 ROOT_START=${BOOTXX_SECS}
@@ -115,7 +127,7 @@ then
        dd if=/dev/zero bs=${EFI_SIZE} count=1 > ${OBJ}/efi.img
        EFI_START=$((${HOME_START} + ${_HOME_SIZE}))
        echo " * EFI"
-       ${CROSS_TOOLS}/nbmakefs -t msdos -s ${EFI_SIZE} -o "F=32,c=1" ${OBJ}/efi.img ${EFI_DIR}
+       ${CROSS_TOOLS}/nbmakefs -t msdos -s ${EFI_SIZE} -o "F=16,c=1" ${OBJ}/efi.img ${EFI_DIR}
        dd if=${OBJ}/efi.img >> ${IMG}
        ${CROSS_TOOLS}/nbpartition -m ${IMG} ${BOOTXX_SECS} 81:${_ROOT_SIZE}* 81:${_USR_SIZE} 81:${_HOME_SIZE} EF:1+
 else


### PR DESCRIPTION
Hybrid BIOS+UEFI bootable disk image. Same image boots on both legacy BIOS and UEFI firmware.

GRUB EFI:
- GRUB 2.06 built from release tarball (stable, no autopoint needed)
- Both BOOTIA32.EFI (32-bit UEFI) and BOOTX64.EFI (64-bit UEFI)
- Kernel + modules stored on EFI partition (FAT16) since GRUB cannot read MINIX MFS partitions
- Dynamic grub.cfg with serial console, novga=1 for UEFI entries
- 10MB EFI System Partition (type 0xEF) as partition 4

Kernel multiboot header fix:
- head.S: Move multiboot header into dedicated .multiboot section
- kernel.lds: Place .multiboot as first section, discard .eh_frame (15KB) to keep header within the 8KB multiboot spec limit
- GRUB EFI can now find and load the MINIX kernel via multiboot

VGA protection for UEFI boot:
- direct_tty_utils.c: direct_con_mode flag suppresses VGA writes
- pre_init.c: Parse novga=1 boot param to disable VGA early
- console.c: Detect UEFI (all-zeros BDA), set nr_cons=0

Tested: QEMU + OVMF x86_64, GRUB menu appears, kernel loads, no panics. Serial console output works.